### PR TITLE
Bugfix: InnerBC are counted twice

### DIFF
--- a/pyhope/mesh/connect/connect.py
+++ b/pyhope/mesh/connect/connect.py
@@ -371,7 +371,7 @@ def ConnectMesh() -> None:
                         # Update the reverse dictionary immediately
                         corner_side[pNodes].append(sideID)
 
-                    if bcs[bcID].type[0] != 1:
+                    if bcs[bcID].type[0] not in (1, 100):
                         bar.step()
 
     # Try to connect the inner / periodic sides


### PR DESCRIPTION
Fixes the incorrect output:
```
Processing Sides |█████████████████████████████████✗︎ (!) 677714/670182 [101%] in 3.2s (216149.57/s)
```
Corrected output:
```
Processing Sides |█████████████████████████████████| 670182/670182 [100%] in 3.1s (218812.67/s)
```