### PR TITLE
Documentation: GitHub Pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,46 @@
+# Simple workflow for deploying documentation to GitHub Pages
+name: Documentation
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches:
+      - main
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
+    steps:
+      - uses: actions/checkout@v4
+      # Setup the credentials for the github-actions[bot]
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: ~/.cache
+          restore-keys: |
+            mkdocs-material-
+      - run: apt-get install pngquant
+      - run: pip install mkdocs-material mkdocs-autorefs
+      - run: mkdocs gh-deploy --force

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ stages:
   - lint
   - compatibility
   - verification
-  - convergence
+  - documentation
 
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 # Linter
@@ -165,7 +165,7 @@ python:3.13:
 #   <<: *compatibility-script
 
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
-# Reggie
+# Verification
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 examples:
   extends: .defaults_coverage
@@ -304,7 +304,7 @@ coverage:
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 convergence:
   extends: .defaults
-  stage: convergence
+  stage: verification
   image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-fedora:42-x86_64
   artifacts:
     paths:
@@ -428,3 +428,28 @@ convergence:
         # Clean-up the log file
         rm -f convergence.log
       done
+
+# ----------------------------------------------------------------------------------------------------------------------------------------------------
+# PyHOPE documentation
+# ----------------------------------------------------------------------------------------------------------------------------------------------------
+documentation:
+  extends: .defaults
+  stage: documentation
+  artifacts:
+    paths:
+      - site
+  before_script:
+    # Setup system
+    - ulimit -s unlimited
+    # - module list || true
+    - python3 --version
+    # Setup uv
+    - uv --version
+    # Setup Python virtual environment
+    - uv venv venv
+    - source venv/bin/activate
+  script:
+    # Install MkDocs
+    - uv pip install --no-cache-dir mkdocs-material mkdocs-autorefs
+    # Build documentation
+    - mkdocs build

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@ authors as mentioned in the [LICENSE.md](LICENSE.md) file.
 The following people contributed major additions or modifications to PyHOPE and
 are listed in alphabetical order:
 
+* Daniel Appel
 * Marcel Blind
 * Stephen Copplestone
 * Patrick Kopper

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,21 @@
+# Authors
+
+PyHOPE's development is coordinated by Patrick Kopper, who is the *principal developer*
+and main contributor. In addition, there are *contributors* who have
+provided substantial additions or modifications. Together, these two groups form
+authors as mentioned in the [LICENSE.md](LICENSE.md) file.
+
+## Principal Developers
+* [Patrick Kopper](https://www.iag.uni-stuttgart.de/en/institute/team/Kopper-00001/),
+  University of Stuttgart, Germany
+
+## Contributors
+The following people contributed major additions or modifications to PyHOPE and
+are listed in alphabetical order:
+
+* Marcel Blind
+* Stephen Copplestone
+* Patrick Kopper
+* Marius Kurz
+* Felix Rodach
+* Anna Schwarz

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,4 @@
+<div class="no-extra-css"></div>
 # Authors
 
 PyHOPE's development is coordinated by the Numerics Research Group (NRG) at 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,7 @@
 # Authors
 
-PyHOPE's development is coordinated by Patrick Kopper, who is the *principal developer*
+PyHOPE's development is coordinated by the Numerics Research Group (NRG) at 
+University of Stuttgart. The primary contact is Patrick Kopper, who is the *principal developer*
 and main contributor. In addition, there are *contributors* who have
 provided substantial additions or modifications. Together, these two groups form
 authors as mentioned in the [LICENSE.md](LICENSE.md) file.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,90 @@
+
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **please contact [Patrick Kopper](mailto:kopper@iag.uni-stuttgart.de), [Andrea Beck](mailto:beck@iag.uni-stuttgart.de), or any other of the principal developers responsible for enforcement listed in [AUTHORS.md](AUTHORS.md).**
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+PyHOPE is an open-source project and we are very happy to accept contributions
+from the community. Please feel free to open issues or submit patches (preferably
+as merge requests) any time. For planned larger contributions, it is often
+beneficial to get in contact with one of the principal developers first (see
+[AUTHORS.md](AUTHORS.md)).
+
+PyHOPE and its contributions are licensed under the GPL-3.0 license (see
+[LICENSE.md](LICENSE.md)). As a contributor, you certify that all your
+contributions are in conformance with the *Developer Certificate of Origin
+(Version 1.1)*, which is reproduced below.
+
+## Developer Certificate of Origin (Version 1.1)
+The following text was taken from
+[https://developercertificate.org](https://developercertificate.org):
+
+    Developer Certificate of Origin
+    Version 1.1
+
+    Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+    Everyone is permitted to copy and distribute verbatim copies of this
+    license document, but changing it is not allowed.
+
+
+    Developer's Certificate of Origin 1.1
+
+    By making a contribution to this project, I certify that:
+
+    (a) The contribution was created in whole or in part by me and I
+        have the right to submit it under the open source license
+        indicated in the file; or
+
+    (b) The contribution is based upon previous work that, to the best
+        of my knowledge, is covered under an appropriate open source
+        license and I have the right under that license to submit that
+        work with modifications, whether created in whole or in part
+        by me, under the same open source license (unless I am
+        permitted to submit under a different license), as indicated
+        in the file; or
+
+    (c) The contribution was provided directly to me by some other
+        person who certified (a), (b) or (c) and I have not modified
+        it.
+
+    (d) I understand and agree that this project and the contribution
+        are public and that a record of the contribution (including all
+        personal information I submit with it, including my sign-off) is
+        maintained indefinitely and may be redistributed consistent with
+        this project or the open source license(s) involved.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,9 +1,0 @@
-# List of Contributors
-
-This is a (possibly incomplete) list of the people who contributed to PyHOPE.
-
-Patrick Kopper<br>
-Marcel Blind<br>
-Anna Schwarz<br>
-Marius Kurz<br>
-Felix Rodach<br>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ pyhope --help
 PyHOPE is heavily inspired by [HOPR (High Order Preprocessor)](https://github.com/hopr-framework/hopr) and shares the same input/output format. For more information and tutorials, please visit the [HOPR documentation](https://hopr.readthedocs.io).
 
 # Usage
-PyHOPE is invoked from the command line. After installation, its functionalities can be accessed directly from the terminal by passing a valid configuration file.
+PyHOPE can either be invoked directly from the command line or used as a Python library.
+
+## Command Line Usage
+PyHOPE can be invoked from the command line. After installation, its functionalities can be accessed directly from the terminal by passing a valid configuration file.
 ```bash
 pyhope [parameter.ini]
 ```
@@ -167,6 +170,15 @@ $ pyhope tutorials/1-01-cartbox/parameter.ini
 ┢━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ┃ PyHOPE completed in [0.25 sec]
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Python Library Usage
+PyHOPE can be included in other Python libraries. PyHOPE exposes its functionally via runtime contexts defined by [Context Managers](https://docs.python.org/3/library/stdtypes.html#typecontextmanager). The following Python code loads a HOPR HDF5 mesh and derived quantities. For a complete list of currently implemented functions, see the [source code](pyhope/__init__.py).
+```python
+from pyhope import Basis, Mesh
+with Mesh('1-01-cartbox_mesh.h5') as m:
+    elems = m.elems
+    lobatto_nodes = Basis.legendre_gauss_lobatto_nodes(order=m.nGeo)
 ```
 
 # Licence

--- a/README.md
+++ b/README.md
@@ -26,31 +26,32 @@ PyHOPE is built using standard Python packages. You can install PyHOPE by follow
     python -m pip install pyhope
     ```
 
-3.  **Optional: Verify PyHOPE installation**  
-    PyHOPE features internal health checks. The checks can be invoked directly from the terminal.
-    ```bash
-    pyhope --verify [tutorials]           # Run all health checks
-    pyhope --verify-health                # Run Python health checks
-    pyhope --verify-install [tutorialss]  # Run PyHOPE mesh generation checks
-    ```
+# Testing
+PyHOPE features internal health checks to verify that everything works as expected. The checks can be invoked directly from the terminal.
+```bash
+pyhope --verify [tutorials]          # Run all health checks
+pyhope --verify-health               # Run Python health checks
+pyhope --verify-install [tutorials]  # Run PyHOPE mesh generation checks
+```
 
 > [!NOTE]  
 >  By default, PyHOPE looks for the `tutorials` directory relative to the current working directory or the git root. If neither exists, PyHOPE downloads the tests from GitHub while using available authentication methods.
 
-4. **Run PyHOPE**  
-    PyHOPE is available as a command-line tool. After installation, its functionalities can be accessed directly from the terminal by passing a valid configuration file.
-    ```bash
-    pyhope [parameter.ini]
-    ```
+# Getting Help
+PyHOPE help output is formatted to serve as self-hosting INI format. A list of all options and the default values can be accessed by running the following command.
+```bash
+pyhope --help
+```
 
-> [!TIP]
-> PyHOPE help output is formatted to serve as self-hosting INI format. A list of all options and the default values can be accessed by running the following command.
-> ```bash
-> pyhope --help
-> ```
+# Documentation
+PyHOPE is heavily inspired by [HOPR (High Order Preprocessor)](https://github.com/hopr-framework/hopr) and shares the same input/output format. For more information and tutorials, please visit the [HOPR documentation](https://hopr.readthedocs.io).
 
 # Usage
-PyHOPE is invoked from the command line. Run parameters are read from a configuration file. The following output is obtained when running the example configuration file `tutorials/1-01-cartbox/parameter.ini`.
+PyHOPE is invoked from the command line. After installation, its functionalities can be accessed directly from the terminal by passing a valid configuration file.
+```bash
+pyhope [parameter.ini]
+```
+The following output is obtained when running the example configuration file `tutorials/1-01-cartbox/parameter.ini`.
 ```
 $ pyhope tutorials/1-01-cartbox/parameter.ini
 ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -167,3 +168,6 @@ $ pyhope tutorials/1-01-cartbox/parameter.ini
 ┃ PyHOPE completed in [0.25 sec]
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
+
+# Licence
+PyHOPE is licensed under the GPL-3.0 license (see [LICENSE.md](LICENSE.md)).

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -1,0 +1,1 @@
+../AUTHORS.md

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/LICENSE.md
+++ b/docs/LICENSE.md
@@ -1,0 +1,1 @@
+../LICENSE.md

--- a/docs/assets/hopr-logo.png
+++ b/docs/assets/hopr-logo.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05744e9be939546e14c784d172d684f6b81d16473d1859f5e8dee6fc2cb4144d
+size 15994

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -32,8 +32,12 @@ div.col-md-9 h1:first-of-type {
 }
 
 /* First text centered */
-body.homepage:not([data-md-page^="AUTHORS.md"]):not([data-md-page^="LICENSE.md"]):not([data-md-page^="CHANGELOG.md"]) div.col-md-9>p:first-of-type {
+div.col-md-9>p:first-of-type {
     text-align: center;
+}
+
+div.col-md-9 > div.no-extra-css + h1:first-of-type + p:first-of-type {
+    text-align: left;
 }
 
 /* == FOOTNOTES == */

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -40,6 +40,11 @@ div.col-md-9 > div.no-extra-css + h1:first-of-type + p:first-of-type {
     text-align: left;
 }
 
+/* == BUTTONS == */
+.btn-spacing {
+  margin-right: 15px; /* Adjust the value to increase or decrease the spacing */
+}
+
 /* == FOOTNOTES == */
 /* .md-typeset .footnote { */
 /*   font-size: 12px; */

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -41,8 +41,29 @@ div.col-md-9 > div.no-extra-css + h1:first-of-type + p:first-of-type {
 }
 
 /* == BUTTONS == */
+.btn {
+  height: 2.3em;
+  display: inline-flex;
+  align-items: center;
+}
+
+.btn img {
+  align-self: center;
+  position: relative;
+  top: 5px;
+  border:     none !important;
+  outline:    none !important;
+  box-shadow: none !important;
+  background: none !important;
+}
+
 .btn-spacing {
-  margin-right: 15px; /* Adjust the value to increase or decrease the spacing */
+  margin-right: 15px;
+}
+
+.btn-hopr {
+  background: #c8c8c8;
+  border-color: #ececec;
 }
 
 /* == FOOTNOTES == */

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1,0 +1,76 @@
+/* == HOMEPAGE == */
+/* Hide the navigation container */
+body.homepage>div.container>div.row>div.col-md-3 {
+    display: none;
+}
+
+/* Full width */
+body.homepage>div.container>div.row>div.col-md-9 {
+    margin-left: 0;
+    flex: 0 0 100%;
+    max-width: 100%;
+}
+
+/* h1 heading centered */
+/* body.homepage>div.container>div.row>div.col-md-9 h1:first-of-type { */
+/*     text-align: center; */
+/*     font-size: 60px; */
+/*     font-weight: 300; */
+/* } */
+
+/* First text centered */
+/* body.homepage>div.container>div.row>div.col-md-9>p:first-of-type { */
+/*     text-align: center; */
+/* } */
+
+/* == HEADERS == */
+/* h1 heading centered */
+div.col-md-9 h1:first-of-type {
+    text-align: center;
+    font-size: 60px;
+    font-weight: 300;
+}
+
+/* First text centered */
+body.homepage:not([data-md-page^="AUTHORS.md"]):not([data-md-page^="LICENSE.md"]):not([data-md-page^="CHANGELOG.md"]) div.col-md-9>p:first-of-type {
+    text-align: center;
+}
+
+/* == FOOTNOTES == */
+/* .md-typeset .footnote { */
+/*   font-size: 12px; */
+/* } */
+
+/* == ALIGNED LIST == */
+.aligned-list {
+    display: grid;
+    grid-template-columns: min-content 1fr;
+    gap: 0 1em;
+}
+
+.aligned-list dt {
+    text-align: left;
+    font-weight: bold;
+    white-space: nowrap;
+    position: relative;
+    padding-left: 1em; /* Add space for the bullet point */
+}
+
+.aligned-list dt::before {
+    content: "•"; /* The character for a bullet point */
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+.aligned-list dd {
+    margin-left: 0;
+    text-align: left;
+}
+
+/* Responsive tweak */
+@media (max-width: 480px) {
+  .aligned-steps > li {
+    column-gap: 0.5rem;
+  }
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,178 @@
+# Getting Started
+
+First steps using PyHOPE
+
+---
+
+## Installation
+PyHOPE is built using standard Python packages. You can install PyHOPE by following these steps. 
+
+1.  **Optional: Create and activate a virtual environment**  
+    Creating a virtual environment is a recommended practice to manage project dependencies. It isolates the packages required for PyHOPE and prevents potential conflicts between different package versions. To create and activate a virtual environment named `venv`, use the following commands.
+    ```bash
+    python -m venv venv
+    source venv/bin/activate
+    ```
+    If you choose not to use a virtual environment, skip this step and proceed directly to the installation of PyHOPE.
+
+    !!! info
+        For new shell sessions, the virtual environment must be re-sourced using `source venv/bin/activate` before using `pyhope` commands.
+
+2.  **Install PyHOPE**  
+    PyHOPE is installed using `pip`, the Python package installer. This command fetches the PyHOPE package and its dependencies from PyPI (Python Package Index) and installs them.
+    ```bash
+    python -m pip install pyhope
+    ```
+
+## Testing
+PyHOPE features internal health checks to verify that everything works as expected. The checks can be invoked directly from the terminal.
+```bash
+pyhope --verify [tutorials]          # Run all health checks
+pyhope --verify-health               # Run Python health checks
+pyhope --verify-install [tutorials]  # Run PyHOPE mesh generation checks
+```
+
+!!! note
+    By default, PyHOPE looks for the `tutorials` directory relative to the current working directory or the git root. If neither exists, PyHOPE downloads the tests from GitHub while using available authentication methods.
+
+## Getting Help
+PyHOPE help output is formatted to serve as self-hosting INI format. A list of all options and the default values can be accessed by running the following command.
+```bash
+pyhope --help
+```
+
+## Usage
+PyHOPE can either be invoked directly from the command line or used as a Python library.
+
+### Command Line Usage
+PyHOPE can be invoked from the command line. After installation, its functionalities can be accessed directly from the terminal by passing a valid configuration file.
+```bash
+pyhope [parameter.ini]
+```
+
+??? example
+    The following output is obtained when running the example configuration file `tutorials/1-01-cartbox/parameter.ini`.
+    ```
+    $ pyhope tutorials/1-01-cartbox/parameter.ini
+    ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ┃ P y H O P E — Python High-Order Preprocessing Environment
+    ┃ PyHOPE version x.x.x
+    ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    │ INIT PROGRAM...
+    │                        nThreads │ 10                              │ DEFAULT │
+    ├─────────────────────────────────────────────
+    │ INIT OUTPUT...
+    │                     ProjectName │ 1-01-cartbox                    │ *CUSTOM │
+    │                    OutputFormat │ 0 [HDF5]                        │ *CUSTOM │
+    │                       DebugVisu │ F                               │ *CUSTOM │
+    ├─────────────────────────────────────────────
+    │ INIT MESH...
+    │                            Mode │ 1 [Internal]                    │ *CUSTOM │
+    │                            NGeo │ 9                               │ *CUSTOM │
+    ├─────────────────────────────────────────────
+    │ GENERATE MESH...
+    ├────
+    │                          nZones │ 1                               │ *CUSTOM │
+    ├── Generating zone 1
+    │                          Corner │ (/0.,0.,0. ,,1.,0.,0. ,,1.,1... │ *CUSTOM │
+    │                          nElems │ (/8,8,8/)                       │ *CUSTOM │
+    │                        ElemType │ 108 [hexahedron]                │ *CUSTOM │
+    │                     StretchType │ (/0,0,0/)                       │ DEFAULT │
+    │                         BCIndex │ (/1,2,3,4,5,6/)                 │ *CUSTOM │
+    ├────
+    ├── Setting boundary conditions
+    ├────
+    │                    BoundaryName │ BC_zminus                       │ *CUSTOM │
+    │                    BoundaryType │ (/4,0,0,0/)                     │ *CUSTOM │
+    │                    BoundaryName │ BC_yminus                       │ *CUSTOM │
+    │                    BoundaryType │ (/2,0,0,0/)                     │ *CUSTOM │
+    │                    BoundaryName │ BC_xplus                        │ *CUSTOM │
+    │                    BoundaryType │ (/2,0,0,0/)                     │ *CUSTOM │
+    │                    BoundaryName │ BC_yplus                        │ *CUSTOM │
+    │                    BoundaryType │ (/2,0,0,0/)                     │ *CUSTOM │
+    │                    BoundaryName │ BC_xminus                       │ *CUSTOM │
+    │                    BoundaryType │ (/2,0,0,0/)                     │ *CUSTOM │
+    │                    BoundaryName │ BC_zplus                        │ *CUSTOM │
+    │                    BoundaryType │ (/9,0,0,0/)                     │ *CUSTOM │
+    ├────
+    │                              vv │ (/1., 0., 0./)                  │ *CUSTOM │
+    │                              vv │ (/0., 1., 0./)                  │ *CUSTOM │
+    │                              vv │ (/0., 0., 1./)                  │ *CUSTOM │
+    ├────
+    ├── Generated mesh with 512 cells
+    ├─────────────────────────────────────────────
+    ├── BUILD DATA STRUCTURE...
+    ├────
+    ├── Removing duplicate points
+    ├── Ensuring normals point outward
+    ├────
+    │             CheckSurfaceNormals │ True                            │ DEFAULT │
+    │             Processing Elements |█████████████████████████████████| 512/512 [100%] in 0.0s (24000.00/s)
+    ├────
+    ├── Generating sides
+    ├─────────────────────────────────────────────
+    │ SORT MESH...
+    ├────
+    │                       doSortIJK │ False                           │ DEFAULT │
+    ├────
+    ├── Sorting elements along space-filling curve
+    ├─────────────────────────────────────────────
+    │ CONNECT MESH...
+    ├────
+    │               doPeriodicCorrect │ False                           │ DEFAULT │
+    │                       doMortars │ True                            │ DEFAULT │
+    ├────
+    │  Number of sides                :         3072
+    │  Number of inner sides          :         2688
+    │  Number of mortar sides (big)   :            0
+    │  Number of mortar sides (small) :            0
+    │  Number of boundary sides       :          384
+    │  Number of periodic sides       :            0
+    ├─────────────────────────────────────────────
+    │ CHECK CONNECTIVITY...
+    ├────
+    │               CheckConnectivity │ True                            │ DEFAULT │
+    │             Processing Elements |█████████████████████████████████| 512/512 [100%] in 0.0s (24000.00/s)
+    ├─────────────────────────────────────────────
+    │ CHECK WATERTIGHTNESS...
+    ├────
+    │             CheckWatertightness │ True                            │ DEFAULT │
+    │             Processing Elements |█████████████████████████████████| 512/512 [100%] in 0.0s (24000.00/s)
+    ├─────────────────────────────────────────────
+    │ CHECK JACOBIANS...
+    ├────
+    │              CheckElemJacobians │ True                            │ DEFAULT │
+    │             Processing Elements |█████████████████████████████████| 512/512 [100%] in 0.0s (24000.00/s)
+    ├────
+    │ Scaled Jacobians
+    ├─────────────────
+    │<0.0      │  0.00
+    │ 0.0-0.1  │  0.00
+    │ 0.1-0.2  │  0.00
+    │ 0.2-0.3  │  0.00
+    │ 0.3-0.4  │  0.00
+    │ 0.4-0.5  │  0.00
+    │ 0.5-0.6  │  0.00
+    │ 0.6-0.7  │  0.00
+    │ 0.7-0.8  │  0.00
+    │ 0.8-0.9  │  0.00
+    │>0.9-1.0  │ ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 512.00
+    ├─────────────────
+    ├─────────────────────────────────────────────
+    │ OUTPUT MESH...
+    ├────
+    │         Curved Hexahedra  :          512
+    ├────
+    ├── Writing HDF5 mesh to "1-01-cartbox_mesh.h5"
+    ┢━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ┃ PyHOPE completed in [0.25 sec]
+    ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    ```
+
+### Python Library Usage
+PyHOPE can be included in other Python libraries. PyHOPE exposes its functionally via runtime contexts defined by [Context Managers](https://docs.python.org/3/library/stdtypes.html#typecontextmanager). The following Python code loads a HOPR HDF5 mesh and derived quantities. For a complete list of currently implemented functions, see the [source code](https://github.com/hopr-framework/PyHOPE/tree/main/pyhope).
+```python
+from pyhope import Basis, Mesh
+with Mesh('1-01-cartbox_mesh.h5') as m:
+    elems = m.elems
+    lobatto_nodes = Basis.legendre_gauss_lobatto_nodes(order=m.nGeo)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,9 +7,9 @@ Mesh Generator for High-Order Meshes in Python
 PyHOPE (Python High-Order Preprocessing Environment) is an open-source Python framework for the generation of three-dimensional unstructured high-order meshes. These meshes are needed by high-order numerical methods like Discontinuous Galerkin, Spectral Element Methods, or pFEM, in order to retain their accuracy if the computational domain includes curved boundaries.
 
 <div class="text-center" style="margin-bottom: 2em;">
-<a href="getting-started/" class="btn btn-primary" role="button">Getting Started</a>
-<a href="user-guide/"      class="btn btn-primary" role="button">User Guide</a>
-<a href="mesh-format/"     class="btn btn-primary" role="button">Mesh Format</a>
+<a href="getting-started/" class="btn btn-primary btn-spacing" role="button">Getting Started</a>
+<a href="user-guide/"      class="btn btn-primary btn-spacing" role="button">User Guide</a>
+<a href="mesh-format/"     class="btn btn-primary btn-spacing" role="button">Mesh Format</a>
 </div>
 
 PyHOPE has been developed by the Numerics Research Group (NRG) lead by Prof. Andrea Beck at the Institute of Aerodynamics and Gas Dynamics at the University of Stuttgart, Germany. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,13 @@ PyHOPE (Python High-Order Preprocessing Environment) is an open-source Python fr
 <a href="mesh-format/"     class="btn btn-primary btn-spacing" role="button">Mesh Format</a>
 </div>
 
-PyHOPE has been developed by the Numerics Research Group (NRG) lead by Prof. Andrea Beck at the Institute of Aerodynamics and Gas Dynamics at the University of Stuttgart, Germany. 
+PyHOPE is heavily inspired by [HOPR (High Order Preprocessor)](https://github.com/hopr-framework/hopr) and shares the same input/output format. HOPR is written in modern Fortran and is maintained as legacy code and as a framework for reference. For more information and tutorials, please refer to the HOPR source code and documentation.
+
+<div class="text-center" style="margin-bottom: 2em;">
+<a href="https://github.com/hopr-framework/hopr" class="btn btn-primary btn-spacing btn-hopr"> <img src="assets/hopr-logo.png" alt="HOPR Logo" style="height:1.5em; vertical-align:middle; margin-right:0.5em;">HOPR Code</a>
+<a href="https://hopr.readthedocs.io"            class="btn btn-primary btn-spacing btn-hopr"> <img src="assets/hopr-logo.png" alt="HOPR Logo" style="height:1.5em; vertical-align:middle; margin-right:0.5em;">HOPR Documentation</a>
+</div>
+
+PyHOPE has been developed by the Numerics Research Group (NRG) led by Prof. Andrea Beck at the Institute of Aerodynamics and Gas Dynamics at the University of Stuttgart, Germany.  
 
 This is a scientific project. If you use PyHOPE for publications or presentations in science, please support the project by citing our publications given at [numericsresearchgroup.org](https://numericsresearchgroup.org/publications.html).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# PyHOPE
+
+Mesh Generator for High-Order Meshes in Python
+
+---
+
+PyHOPE (Python High-Order Preprocessing Environment) is an open-source Python framework for the generation of three-dimensional unstructured high-order meshes. These meshes are needed by high-order numerical methods like Discontinuous Galerkin, Spectral Element Methods, or pFEM, in order to retain their accuracy if the computational domain includes curved boundaries.
+
+<div class="text-center" style="margin-bottom: 2em;">
+<a href="getting-started/" class="btn btn-primary" role="button">Getting Started</a>
+<a href="user-guide/"      class="btn btn-primary" role="button">User Guide</a>
+<a href="mesh-format/"     class="btn btn-primary" role="button">Mesh Format</a>
+</div>
+
+PyHOPE has been developed by the Numerics Research Group (NRG) lead by Prof. Andrea Beck at the Institute of Aerodynamics and Gas Dynamics at the University of Stuttgart, Germany. 
+
+This is a scientific project. If you use PyHOPE for publications or presentations in science, please support the project by citing our publications given at [numericsresearchgroup.org](https://numericsresearchgroup.org/publications.html).

--- a/docs/mesh-format.md
+++ b/docs/mesh-format.md
@@ -1,0 +1,169 @@
+# Mesh Format
+
+HOPR HDF5 curved mesh format used by PyHOPE
+
+---
+
+The [HOPR](https://hopr.readthedocs.io/en/latest/userguide/meshformat.html) [HDF5](http://www.hdfgroup.org) mesh format is designed for fast, scalable, parallel I/O of high-order unstructured 3D meshes. Mesh data is organized in non-overlapping arrays and packaged per element to minimize synchronization. A space-filling curve or structured ordering enables simple domain decomposition.
+
+The following spectral element solvers have (optional) support for meshes generated in PyHOPE.
+
+| <div style="width:120px">Framework</div> | <div style="width:100px">Language</div> | <div style="width:200px">Equation System</div> | <div style="width:300px">Reference</div> |
+| ---------------------------------------- | --------------------------------------- | ---------------------------------------------- | ---------------------------------------- |
+| FLEXI                                    | Fortran                                 | NSE                                            | [Krais et al., 2021](https://doi.org/10.1016/j.camwa.2020.05.004) |
+| ƎLEXI                                    | Fortran                                 | NSE/MRG                                        | [Kopper et al., 2023](https://doi.org/10.1016/j.cpc.2023.108762)  |
+| GALÆXI                                   | Fortran/C                               | NSE                                            | [Kurz et al., 2025](https://doi.org/10.1016/j.cpc.2024.109388)    |
+| FLUXO                                    | Fortran                                 | NSE/MHD/Maxwell                                | [Rueda-Ramirez et al., 2017](https://github.com/project-fluxo/fluxo) |
+| HORSES3D                                 | Fortran                                 | NSE/Cahn-Hilliard                              | [Ferrer et al., 2023](https://doi.org/10.1016/j.cpc.2023.108700)  |
+| PICLas                                   | Fortran                                 | Maxwell/Poisson                                | [Fasoulas et al., 2019](https://doi.org/10.1063/1.5097638)        |
+
+<style>.footnote {  font-size: 0.8em; }
+</style>
+<div class="footnote">
+<p>Equation Systems: NSE - Navier-Stokes, MRG - Maxey-Riley-Gatignol, MHD - Magnetohydrodynamics</p>
+</div>
+<!-- +--------------+-------------+-------------------------+--------------------------------------------+ -->
+<!-- | Framework    | Language    | Equation System         | Reference                                  | -->
+<!-- +:=============+:============+:========================+:===========================================+ -->
+<!-- | FLEXI        | Fortran     | NSE                     | [@Krais2021]                               | -->
+<!-- +--------------+-------------+-------------------------+--------------------------------------------+ -->
+<!-- | ƎLEXI        | Fortran     | NSE/MRG                 | [@Kopper2023]                              | -->
+<!-- +--------------+-------------+-------------------------+--------------------------------------------+ -->
+<!-- | GALÆXI       | Fortran/C   | NSE                     | [@Kurz2025]                                | -->
+<!-- +--------------+-------------+-------------------------+--------------------------------------------+ -->
+<!-- | FLUXO        | Fortran     | NSE/MHD/Maxwell         | [@RuedaRamirez2017]                        | -->
+<!-- +--------------+-------------+-------------------------+--------------------------------------------+ -->
+<!-- | HORSES3D     | Fortran     | NSE/Cahn-Hilliard       | [@Ferrer2023]                              | -->
+<!-- +--------------+-------------+-------------------------+--------------------------------------------+ -->
+<!-- | PICLas       | Fortran     | Maxwell/Poisson         | [@Fasoulas2019]                            | -->
+<!-- +==============+=============+=========================+============================================+ -->
+<!-- | ~*Equation Systems: NSE - Navier-Stokes, MRG - Maxey-Riley-Gatignol, MHD - Magnetohydrodynamics*~ | -->
+<!-- +==============+=============+===========================+==========================================+ -->
+
+<!-- - Supports straight and curved elements of arbitrary order (tetrahedra, pyramids, prisms, hexahedra) -->
+<!-- - Parallel-friendly: contiguous per-element blocks and array hyperslabs for MPI I/O -->
+<!-- - Optional FEM connectivity for solvers that require edge/vertex topology -->
+
+## Global Attributes
+
+| <div style="width:120px">Attribute</div> | <div style="width:240px">Type</div> | Description                                                 |
+| ---------------------------------------- | ----------------------------------- | ----------------------------------------------------------- |
+| `Version`                                | REAL                                | Mesh file format version                                    |
+| `Ngeo`                                   | INTEGER                             | Polynomial degree of the curved element mapping             |
+| `nElems`                                 | INTEGER                             | Total number of elements                                    |
+| `nSides`                                 | INTEGER                             | Total number of sides (element faces)                       |
+| `nNodes`                                 | INTEGER                             | Total number of nodes                                       |
+| `nUniqueSides`                           | INTEGER                             | Total number of geometrically unique sides                  |
+| `nUniqueNodes`                           | INTEGER                             | Total number of geometrically unique nodes                  |
+| `nBCs`                                   | INTEGER                             | Number of entries in the boundary-condition list            |
+| `FEMconnect`                             | `ON`/`OFF`                          | `ON` if FEM edge/vertex connectivity is present in the file |
+
+## Data Arrays
+
+| <div style="width:120px">Array</div> | <div style="width:80px">Type</div> | <div style="width:200px">Size</div>  | Description              |
+| ------------------------------------ | ----------------------------------- | ----------------------------------- | ------------------------ |
+| `ElemInfo`                           | INTEGER                             | (1:6, 1:nElems)                     | Per-element data containing element type, zone, and offsets into side and node arrays: `(ElemType, Zone, offsetIndSIDE, lastIndSIDE, offsetIndNODE, lastIndNODE)`. |
+| `SideInfo`                           | INTEGER                             | (1:6, 1:nSides)                     | Per-side data stored contiguously per element range from `ElemInfo`. Fields: `(SideType, GlobalSideID, nbElemID, 10*nbLocSide+Flip, BCID, [ElemID,locSideID])`. `Flip` encodes side orientation; `GlobalSideID<0` marks slave side. |
+| `NodeCoords`                         | REAL                                | (1:3, 1:nNodes)                     | Node coordinates, stored per element range from `ElemInfo`. High-order nodes included. |
+| `GlobalNodeIDs`                      | INTEGER                             | (1:nNodes)                          | Globally unique node IDs aligned with `NodeCoords` |
+| `BCNames`                            | STRING                              | (1:nBCs)                            | List of user-defined boundary-condition names |
+| `BCType`                             | INTEGER                             | (1:4, 1:nBCs)                       | Four-integer code per boundary condition; see [boundary conditions](#boundary-conditions) below |
+
+## Element Definitions
+
+Elements are defined using non-unique node IDs stored in `ElemInfo` and `NodeCoords`. Each element has a type code and a zone ID. The zone ID can be used to group elements into physical zones or blocks.
+
+### Element Types
+
+The element encoding follows CGNS-inspired conventions. The last digit of the surface type corresponds to corner count; 3D element codes distinguish linear, bilinear, and non-linear variants.
+
+| Element Type               | Index | Element Type               | Index | Element Type               | Index |
+| -------------------------- | ----- | -------------------------- | ----- | -------------------------- | ----- |
+| Tetrahedron, linear        | 104   | Tetrahedron, bilinear      | 114   | Tetrahedron, curved        | 204   |
+| Pyramid, linear            | 105   | Pyramid, bilinear          | 115   | Pyramid, curved            | 205   |
+| Prism/wedge, linear        | 106   | Prism/wedge, bilinear      | 116   | Prism/wedge, curved        | 206   |
+| Hexahedron, linear         | 108   | Hexahedron, bilinear       | 118   | Hexahedron, curved         | 208   |
+
+### High-Order Nodes
+
+High-order nodes are stored in tensor-product style using (i,j,k) with uniform spacing in reference space \([-1, 1]^3\). Note that for `NGeo=1`, this node ordering differs from CGNS corner ordering for pyramids and hexahedra as the nodes `3`/`4` and `7`/`8` are swapped. The number of nodes per element depends on `NGeo` and element type.
+
+<dl class="aligned-list">
+    <dt><code>Tetrahedron</code>:</dt>
+    <dd>\((Ngeo+1)(Ngeo+2)(Ngeo+3)/6\)</dd>
+    <dt><code>Pyramid</code>:</dt>
+    <dd>\((Ngeo+1)(Ngeo+2)(2Ngeo+3)/6\)</dd>
+    <dt><code>Prism/Wedge</code>:</dt>
+    <dd>\((Ngeo+1)^2(Ngeo+2)/2\)</dd>
+    <dt><code>Hexahedron</code>:</dt>
+    <dd>\((Ngeo+1)^3\)</dd>
+</dl>
+
+## Boundary Conditions
+
+`BCNames` and `BCType` define the available boundary conditions. `BCID` in `SideInfo` references a 1-based index into these arrays and uses `0` for interior sides. `BCType = (BoundaryType, CurveIndex, StateIndex, PeriodicIndex)` contains four integers per boundary condition:
+
+<dl class="aligned-list">
+    <dt><code>BoundaryType</code>:</dt>
+    <dd>Integer code for the BC kind. Reserved values: <code>1</code> = periodic; <code>100</code> = inner/analyze sides. Periodic and inner sides also have neighbor links defined.</dd>
+    <dt><code>CurveIndex</code>:</dt>
+    <dd><i>Geometry/CAD tag to distinguish BCs or trigger curving behavior. Currently unused in PyHOPE.</i></dd>
+    <dt><code>BoundaryState</code>:</dt>
+    <dd>User-defined index for solver reference states; not interpreted by the format.</dd>
+    <dt><code>PeriodicIndex</code>:</dt>
+    <dd>Used only for periodic sides; two matching BCs must share the same absolute value, with opposite signs.</dd>
+</dl>
+
+<!-- ## Parallel Read-In (Overview) -->
+<!---->
+<!-- The [HOPR](https://hopr.readthedocs.io/en/latest/userguide/meshformat.html) format supports efficient parallel reading with minimal communication. The [HDF5](http://www.hdfgroup.org) library allows usage of parallel MPI-I/O, enabling scalable read-in of large meshes. By default, elements in [HOPR](https://hopr.readthedocs.io/en/latest/userguide/meshformat.html) files are ordered along structured dimensions or a space-filling curve, which facilitates simple domain decomposition. This permits using the same element ordering and thus mesh file with an arbitrary number of computational domains (≥ number of elements).  -->
+<!---->
+<!-- Neighbor connectivity information of element sides and element node information (index and position) are stored as a package per element, allowing reading contiguous data blocks for a given range of elements. To enable a fast parallel read-in, the coordinates of the same physical nodes are stored multiple times, but can be still associated by a unique global node index. -->
+<!---->
+<!-- The following outlines a high-level approach to load the mesh into a supported solver: -->
+<!---->
+<!-- 1. **Domain Decomposition**: Distribute contiguous element ranges across ranks. The element range for each domain \(\text{dom} \in [0:\text{nDom}-1]\) is \( \text{range}(\text{dom})=[\text{offsetElem}(\text{dom})+1; \text{offsetElem}(\text{myDom}+1)] \). -->
+<!-- 2. **Element Read-In**: Read the local subarray of `ElemInfo` (HDF5 hyperslabs), then compute local ranges for `SideInfo` and `NodeCoords` via `offsetInd*`/`lastInd*`. -->
+<!-- 3. **Connectivity Building**: Build local connectivity; for inter-domain connections, locate the owning domain via element-range offsets (bisection over offsets). -->
+<!-- 4. **Side Matching**: Group sides per neighbor domain and sort by `GlobalSideID` to obtain matching lists on both sides without communication. -->
+<!-- 5. **Orientation Handling**: Master/slave and orientation are encoded consistently in `GlobalSide` sign and `Flip`/edge-orientation fields. -->
+
+<!-- <dl class="aligned-list"> -->
+<!--     <dt>Domain Decomposition:</dt> -->
+<!--     <dd>Distribute contiguous element ranges across ranks. The element range for each domain \(\text{dom} \in [0:\text{nDom}-1]\) is \( \text{range}(\text{dom})=[\text{offsetElem}(\text{dom})+1; \text{offsetElem}(\text{myDom}+1)] \).</dd> -->
+<!--     <dt>Element Read-In:</dt> -->
+<!--     <dd>Read the local subarray of <code>ElemInfo</code> (HDF5 hyperslabs), then compute local ranges for <code>SideInfo</code> and <code>NodeCoords</code> via <code>offsetInd*</code>/<code>lastInd*</code>.</dd> -->
+<!--     <dt>Connectivity Building:</dt> -->
+<!--     <dd>Build local connectivity; for inter-domain connections, locate the owning domain via element-range offsets (bisection over offsets).</dd> -->
+<!--     <dt>Side Matching:</dt> -->
+<!--     <dd>Group sides per neighbor domain and sort by <code>GlobalSideID</code> to obtain matching lists on both sides without communication.</dd> -->
+<!--     <dt>Orientation Handling:</dt> -->
+<!--     <dd>Primary/replica and orientation are encoded consistently in <code>GlobalSideID</code> signs and <code>Flip</code>/edge-orientation fields.</dd> -->
+<!-- </dl> -->
+
+## FEM Connectivity
+
+PyHOPE can optionally store additional connectivity information required by Finite Element Method (FEM)-based solvers. This includes topological connectivity of edges and vertices, as well as their connections across elements. This information is included when the global attribute `FEMconnect` is set to `ON`.
+
+### Global Attributes
+
+| <div style="width:120px">Attribute</div> | <div style="width:240px">Type</div> | Description                                                 |
+| ---------------------------------------- | ----------------------------------- | ----------------------------------------------------------- |
+| `nEdges`                                 | INTEGER                             | Total number of entries in `EdgeInfo`                       |
+| `nVertices`                              | INTEGER                             | Total number of entries in `VertexInfo`                     |
+| `nUniqueEdges`                           | INTEGER                             | Total number of geometrically unique edges                  |
+| `nFEMSides`                              | INTEGER                             | Number of topologically (incl. periodicity) unique sides    |
+| `nFEMEdges`                              | INTEGER                             | Number of topologically unique edges                        |
+| `nFEMEdgeConnections`                    | INTEGER                             | Size of `EdgeConnectInfo`                                   |
+| `nFEMVertices`                           | INTEGER                             | Number of topologically unique vertices                     |
+| `nFEMVertexConnections`                  | INTEGER                             | Size of `VertexConnectInfo`                                 |
+
+### Data Arrays
+
+| <div style="width:120px">Array</div> | <div style="width:80px">Type</div> | <div style="width:200px">Size</div>  | Description              |
+| ------------------------------------ | ----------------------------------- | ----------------------------------- | ------------------------ |
+| `FEMElemInfo`                        | INTEGER                             | (1:4, 1:nElems)                     | Per-element offsets into `EdgeInfo` and `VertexInfo`: `(offsetIndEDGE, lastIndEDGE, offsetIndVERTEX, lastIndVERTEX)`. |
+| `EdgeInfo`                           | INTEGER                             | (1:3, 1:nEdges)                     | For each local element edge (CGNS order): `(±FEMEdgeID, offsetIndEDGEConnect, lastIndEDGEConnect)`. Sign encodes local-to-global orientation. |
+| `EdgeConnectInfo`                    | INTEGER                             | (1:2, 1:nFEMEdgeConns)              | Edge connections: `(±nbElemID, ±nbLocEdgeID)`. Sign on `nbElemID` encodes primary/replica; sign on `nbLocEdgeID` encodes orientation. |
+| `VertexInfo`                         | INTEGER                             | (1:3, 1:nVertices)                  | For each local vertex (CGNS corner order): `(FEMVertexID, offsetIndVERTEXConnect, lastIndVERTEXConnect)`. |
+| `VertexConnectInfo`                  | INTEGER                             | (1:2, 1:nFEMVertexConns)            | Vertex connections: `(±nbElemID, nbLocVertexID)`. Sign encodes primary/replica. |

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,0 +1,22 @@
+# Introduction
+
+Scope and Features of PyHOPE
+
+---
+
+High-order numerical methods surch as Discontinuous Galerkin, Spectral Element Methods, or pFEM, require unstructured high-order meshes in order to retain their accuracy if the computational domain includes curved boundaries. The HOPR HDF5 curved mesh format is specifically designed to specifically designed for parallel read-in of unstructured three-dimensional meshes of arbitrary order, including tetrahedra, pyramids, prisms, and hexahedra. Information stored in HOPR format facilitates non-overlapping input output (I/O) through collocation of the required mesh information, including the vertex and side information together with element connectivity, in per-element packages. Each package is assigned a unique identifier via ordering along structured dimensions or a space-filling curve.
+
+PyHOPE is a Python library for reading, writing, and manipulating HOPR HDF5 curved mesh files. At the current state, it features two modes for mesh generation:
+
+- [Internal mesh generator](mesh-generators/internal.md): A simple mesh generator for generating curved meshes of basic block-structured geometries 
+- [External mesh generator](mesh-generators/external.md): An interface to read and convert meshes generated with external mesh generators such as ANSA, Gmsh, or Cubit
+
+PyHOPE is controlled via a parameter file in INI format. The parameter file specifies the mesh generation mode, the geometry and mesh parameters, and the output file name.
+
+- [Parameter file format](parameter-file.md): Description of the parameter file format and available options
+
+PyHOPE is heavily inspired by [HOPR (High Order Preprocessor)](https://github.com/hopr-framework/hopr) and shares the same input/output format. 
+
+- [Mesh Format](../mesh-format.md): Brief description of the HOPR HDF5 mesh format
+
+For more information and tutorials, please visit the [HOPR documentation](https://hopr.readthedocs.io). Furthermore, PyHOPE utilizes [Gmsh](https://gmsh.info) for the initial mesh generation and conversion before switching to its internal representation. The internal representation is loosely based on [meshio](https://github.com/nschloe/meshio) but augmented with additional information required for high-order meshes.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,15 +1,19 @@
 # Introduction
 
-Scope and Features of PyHOPE
+Scope and features of PyHOPE
 
 ---
 
 High-order numerical methods surch as Discontinuous Galerkin, Spectral Element Methods, or pFEM, require unstructured high-order meshes in order to retain their accuracy if the computational domain includes curved boundaries. The HOPR HDF5 curved mesh format is specifically designed to specifically designed for parallel read-in of unstructured three-dimensional meshes of arbitrary order, including tetrahedra, pyramids, prisms, and hexahedra. Information stored in HOPR format facilitates non-overlapping input output (I/O) through collocation of the required mesh information, including the vertex and side information together with element connectivity, in per-element packages. Each package is assigned a unique identifier via ordering along structured dimensions or a space-filling curve.
 
-PyHOPE is a Python library for reading, writing, and manipulating HOPR HDF5 curved mesh files. At the current state, it features two modes for mesh generation:
+PyHOPE is a Python library for reading, writing, and manipulating HOPR HDF5 curved mesh files. 
+
+- [Installation](../getting-started.md): Installation and verification of the local installation of PyHOPE
+
+At the current state, it features two modes for mesh generation:
 
 - [Internal mesh generator](mesh-generators/internal.md): A simple mesh generator for generating curved meshes of basic block-structured geometries 
-- [External mesh generator](mesh-generators/external.md): An interface to read and convert meshes generated with external mesh generators such as ANSA, Gmsh, or Cubit
+- [External mesh generator](mesh-generators/external.md): Read and convert meshes generated with external mesh generators such as ANSA, Gmsh, or Cubit
 
 PyHOPE is controlled via a parameter file in INI format. The parameter file specifies the mesh generation mode, the geometry and mesh parameters, and the output file name.
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -8,7 +8,7 @@ High-order numerical methods surch as Discontinuous Galerkin, Spectral Element M
 
 PyHOPE is a Python library for reading, writing, and manipulating HOPR HDF5 curved mesh files. 
 
-- [Installation](../getting-started.md): Installation and verification of the local installation of PyHOPE
+- [Installation](installation.md): Installation and verification of the local installation of PyHOPE
 
 At the current state, it features two modes for mesh generation:
 

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -1,0 +1,1 @@
+../getting-started.md

--- a/docs/user-guide/mesh-generators/external.md
+++ b/docs/user-guide/mesh-generators/external.md
@@ -1,0 +1,39 @@
+# External Mesh Generator
+
+An interface to read and convert meshes generated with external mesh generators
+
+---
+
+PyHOPE internally utilizes [Gmsh](https://gmsh.info) for the initial mesh generation and conversion before switching to its internal representation. The internal representation is loosely based on [meshio](https://github.com/nschloe/meshio) but augmented with additional information required for high-order meshes. This allows to read and convert meshes generated with external mesh generators such as ANSA, Gmsh, or Cubit.
+
+!!! info
+    PyHOPE currently comes with a patched version of Gmsh which includes a fix for serendipity elements and the internal CGNS updated to version to `v4.5`. While PyHOPE can work with the upstream version of Gmsh, it is recommended to use the provided patched version. Future releases of Gmsh might include the required fixes.
+
+## File Formats
+
+An external mesh is specified via the `3`/`external` mesh generation `Mode` in the [parameter file](../parameter-file.md), combined with one or more mesh `FileName`. The file format is automatically detected based on the file extension. Files might be read through Gmsh or internal readers. If multiple files are specified, they are merged into a single mesh. In this case, it is assumed that the meshes do not overlap and that the boundary information is consistent across the files. File formats supported and regularly tested during Continuous Integration (CI) are listed in the table below.
+
+| File Format                             | Extension                            | Reader                                   |
+| ----------------------------------------| -------------------------------------| ---------------------------------------- |
+| GMSH ASCII/Binary                       | `.msh`                               | Gmsh                                     |
+| CFD General Notation System (CGNS)      | `.cgns`                              | Gmsh<a href="#fn1" id="fnref1">¹</a>     |
+| High Order Preprocessor (HOPR)          | `.h5`                                | Internal                                 |
+| Gambit Neutral File (GNF)               | `.neu`                               | Internal<a href="#fn2" id="fnref2">²</a> |
+
+<style>.footnote {  font-size: 0.8em; }
+</style>
+<div class="footnote">
+<p><a href="#fnref1" id="fn1">¹</a> PyHOPE requires additional boundary information to read CGNS files through Gmsh. An internal reader is called after Gmsh to extract the required information.</p>
+<p><a href="#fnref2" id="fn2">²</a> PyHOPE uses its own internal reader for GNF files as the reader contained in Gmsh currently does not support all required features.</p>
+</div>
+
+## Mesh Curving
+
+PyHOPE understands curved meshes of arbitrary order if the external mesh generator provided already curved mesh. PyHOPE reads these meshes and directly uses their high-order information. Existing high-order meshes from other sources can thus be directly translated into the HDF5 format. Furthermore, available post-processing capabilities can be applied to these meshes. If more than one external mesh file is specified, each mesh is interpolated to the desired order specified via the `NGeo` parameter in the [parameter file](../parameter-file.md).
+
+### Curving through Agglomeration
+
+PyHOPE can utilize the agglomeration approach provided by Gmsh to curve linear meshes. In this case, the external mesh generator is used to generate a linear mesh, which is then curved through agglomeration in Gmsh before being read into PyHOPE. To use this approach, set the `NGeo` parameter in the [parameter file](../parameter-file.md) to the desired order larger than `1`. 
+
+## Generation of Hexahedral Meshes
+Many solvers require purely hexahedral meshes. PyHOPE can convert meshes consisting of tetrahedra, prisms and hexahedra into purely hexahedral meshes through a subdivision strategy. This feature is activated using the parameter `splitToHex=T`. Note, that pyramids cannot be decomposed to hexahedra in a straightforward way, thus this feature cannot be applied to meshes containing pyramids. Also note that this option is currently limited to `NGeo` \(\in\{1,2,4\}\).

--- a/docs/user-guide/mesh-generators/external.md
+++ b/docs/user-guide/mesh-generators/external.md
@@ -1,6 +1,6 @@
 # External Mesh Generator
 
-An interface to read and convert meshes generated with external mesh generators
+Read and convert meshes generated with external mesh generators
 
 ---
 

--- a/docs/user-guide/mesh-generators/external.md
+++ b/docs/user-guide/mesh-generators/external.md
@@ -16,7 +16,7 @@ An external mesh is specified via the `3`/`external` mesh generation `Mode` in t
 | File Format                             | Extension                            | Reader                                   |
 | ----------------------------------------| -------------------------------------| ---------------------------------------- |
 | GMSH ASCII/Binary                       | `.msh`                               | Gmsh                                     |
-| CFD General Notation System (CGNS)      | `.cgns`                              | Gmsh<a href="#fn1" id="fnref1">¹</a>     |
+| CFD General Notation System (CGNS)      | `.cgns`                              | Gmsh + Internal<a href="#fn1" id="fnref1">¹</a>     |
 | High Order Preprocessor (HOPR)          | `.h5`                                | Internal                                 |
 | Gambit Neutral File (GNF)               | `.neu`                               | Internal<a href="#fn2" id="fnref2">²</a> |
 

--- a/docs/user-guide/mesh-generators/internal.md
+++ b/docs/user-guide/mesh-generators/internal.md
@@ -1,0 +1,142 @@
+# Internal Mesh Generator
+
+A simple internal mesh generator for generating curved meshes of basic block-structured geometries
+
+---
+
+The internal generator creates structured, block-wise meshes (Cartesian boxes) with options for multi-zone setups, periodic couplings, and graded (stretched) element distributions.
+
+## Mesh Specification
+
+Internal meshes are specified using exclusively the [INI parameter file format](../parameter-file.md). As internal meshes are created using zones with 8 corner nodes, each zone is limited to a Cartesian box geometry (before mesh post-processing). The following minimal parameter file can be found in `tutorials/1-01-cartbox` and generates a simple Cartesian box mesh.
+
+```ini
+!================================================================================================================================= !
+! OUTPUT
+!================================================================================================================================= !
+ProjectName  = 1-01-cartbox                         ! Name of output files
+OutputFormat = HDF5                                 ! Mesh output format (HDF5 VTK)
+
+!================================================================================================================================= !
+! MESH
+!================================================================================================================================= !
+Mode         = 1                                    ! Mode for Cartesian boxes
+nZones       = 1                                    ! Number of boxes
+Corner       = (/0.,0.,0. ,,1.,0.,0. ,,1.,1.,0. ,,  0.,1.,0.,, 0.,0.,1. ,,1.,0.,1. ,,1.,1.,1. ,,  0.,1.,1. /)
+                                                    ! Corner node positions: (/ x_1,y_1,z_1, x_2,y_2,z_2,..... , x_8,y_8,z_8/)
+nElems       = (/8,8,8/)                            ! Number of elements in each direction
+BCIndex      = (/1,2,3,4,5,6/)                      ! Indices of boundary conditions for six boundary faces (z-,y-,x+,y+,x-,z+)
+ElemType     = 108                                  ! Element type (104: Tetrahedra, 105: Pyramid, 106: Prism, 108: Hexahedral)
+nGeo         = 9
+
+!================================================================================================================================= !
+! BOUNDARY CONDITIONS
+!================================================================================================================================= !
+BoundaryName = BC_zminus                            ! BC index 1 (from position in parameterfile)
+BoundaryType = (/4,0,0,0/)                          ! (/ Type, curveIndex, State, alpha /)
+BoundaryName = BC_yminus                            ! BC index 2
+BoundaryType = (/2,0,0,0/)
+BoundaryName = BC_xplus                             ! BC index 3
+BoundaryType = (/2,0,0,0/)
+BoundaryName = BC_yplus                             ! BC index 4
+BoundaryType = (/2,0,0,0/)
+BoundaryName = BC_xminus                            ! BC index 5
+BoundaryType = (/2,0,0,0/)
+BoundaryName = BC_zplus                             ! BC index 6
+BoundaryType = (/9,0,0,0/)
+```
+
+### Multiple Cartesian Boxes
+
+PyHOPE supports multi-zone setups consisting of multiple Cartesian boxes. Each box, refered to as zone, is defined by its 8 corner nodes specified in the `Corner` vector. The number of elements in each direction for each box is specified in the `nElems` vector. If boxes are connected with each other, the corner nodes of the touching element faces must either be identical or be placed on the center of the element edge (non-conforming interfaces with hanging nodes).
+
+## Boundary Conditions
+
+Boundary conditions are specified in the parameter file using the `BoundaryName` and `BoundaryType` keywords. The order of the boundary conditions is determined by the order of the boundary faces given as `z-,y-,x+,y+,x-,z+` inside the `BCIndex` vector. Indices can be applied repeatedly.
+
+### Periodic Boundary Conditions
+
+Boundary faces can be coupled periodically by specifying the `BoundaryType = (/1,0,0,-1/)` where the last entry `alpha` specifies the periodic displacement vector to be used. A negative alpha corresponds to a displacement vector applied in the opposite direction. Displacement vectors are indexed in the order of appearance in parameter file. The following minimal parameter file can be found in `tutorials/1-02-cartbox-periodic` and generates a Cartesian box mesh with periodic coupling in x- and y-direction.
+
+```ini
+!================================================================================================================================= !
+! OUTPUT
+!================================================================================================================================= !
+ProjectName  = 1-02-cartbox_periodic                ! Name of output files
+Debugvisu    = F                                    ! Launch the GMSH GUI to visualize the mesh
+OutputFormat = HDF5                                 ! Mesh output format (HDF5 VTK)
+
+!================================================================================================================================= !
+! MESH
+!================================================================================================================================= !
+Mode         = 1                                    ! Mode for Cartesian boxes
+nZones       = 1                                    ! Number of boxes
+Corner       = (/0.,0.,0. ,,1.,0.,0. ,,1.,1.,0. ,,  0.,1.,0.,, 0.,0.,1. ,,1.,0.,1. ,,1.,1.,1. ,,  0.,1.,1. /)
+                                                    ! Corner node positions: (/ x_1,y_1,z_1, x_2,y_2,z_2,..... , x_8,y_8,z_8/)
+nElems       = (/2,3,4/)                            ! Number of elements in each direction
+BCIndex      = (/1,3,6,4,5,2/)                      ! Indices of boundary conditions for six boundary faces (z-,y-,x+,y+,x-,z+)
+ElemType     = 108                                  ! Element type (108: Hexahedral)
+doFEMConnect = T                                    ! Generate finite element method (FEM) connectivity
+
+!================================================================================================================================= !
+! BOUNDARY CONDITIONS
+!================================================================================================================================= !
+BoundaryName = BC_zminus                            ! BC index 1 (from position in parameterfile)
+BoundaryType = (/1,0,0,1/)                          ! (/ Type, curveIndex, State, alpha /)
+BoundaryName = BC_zplus                             ! BC index 2
+BoundaryType = (/1,0,0,-1/)                         ! here the direction of the vector 1 is changed, because it is the opposite side
+vv = (/0.,0.,1./)                                   ! vector for periodic BC in z direction (zminus,zplus), index=1
+
+BoundaryName = BC_yminus                            ! BC index 3
+BoundaryType = (/1,0,0,2/)
+BoundaryName = BC_yplus                             ! BC index 4
+BoundaryType = (/1,0,0,-2/)                         ! (/ BCType=1: periodic, 0, 0, Index of second vector vv in parameter file /)
+vv = (/0.,1.,0./)                                   ! vector for periodic BC in y direction (yminus,yplus), index=2
+
+BoundaryName = BC_inflow                            ! BC index 5
+BoundaryType = (/2,0,0,0/)
+BoundaryName = BC_outflow                           ! BC index 6
+BoundaryType = (/2,0,0,0/)
+```
+
+## Stretching Functions
+
+By default, elements are distributed uniformly in each direction within each transfinite mesh zone. Stretching (grading) of the element distribution used to generate a mesh consisting of boxes with a stretched element arrangement. The following parameters control the stretching and are defined for each zone separately.
+
+<dl class="aligned-list">
+    <dt><code>StrechType</code>:</dt>
+    <dd>Stretching type. Possible values are <code>0</code> (no stretching, uniform element distribution), <code>1</code> (stretching with progression factor), <code>2</code> (stretching with a length ratio) and <code>3</code> (stretching with a bell function).</dd>
+    <dt><code>factor</code>:</dt>
+    <dd>Stretching factor. Values > 1.0 lead to an exponential increase of the element size in the respective direction, values < 1.0 lead to an exponential decrease of the element size in the respective direction. A value of 1 has no effect on the element sizes, and a value of 0 disables the stretching function for this axis. Furthermore, the stretching behavior can be mirrored by adding a negative sign to the values. A combination with the parameter <code>l0</code> ignores the element number of the defined box.</dd>
+    <dt><code>l0</code>:</dt>
+    <dd>Length scale. The length of the first element of a stretched element arrangement of a Cartesian box. Each component of the vector represents an axis of the Cartesian coordinate system. A value of 0 disables the stretching function for that axis. A negative sign defines the length of the first element of the other side of the box. A combination with the parameter <code>factor</code> ignores the element number of the defined box.</dd>
+    <dt><code>DXmaxToDXmin</code>:</dt>
+    <dd>Frame ratio. The ratio of the largest to the smallest element size in the respective direction. If the <code>stretchType</code> vector component for an axis is <code>3</code>, the element arrangement is controlled by <code>DXmaxToDXmin</code> instead of the parameter <code>fac</code>.</dd>
+</dl>
+
+### Calculation Formulas
+
+The stretching functions are applied in each direction independently. The following formulas are used to calculate the element sizes and positions.
+
+- Calculation of the element size for `stretchType=1`:
+
+\[ {\Delta x_{i+1} = f \cdot \Delta x_{i} f = \left(\frac{\Delta x_{max}}{\Delta x_{min}} \right)^{1/(nElems - 1)} } \]
+
+- Calculation of the element size for `stretchType=3`:
+
+\[ \Delta x(\xi) \sim 1 + \left( \frac{\Delta x_{max}}{\Delta x_{min}}-1\right)\cdot \left( \frac{\exp[-(\xi \cdot f)^2] - \exp[-f^2]}{\exp[0] - \exp[-f^2]}\right) \]
+
+## Post-Deformation
+
+Mesh zones can be deformed after the initial mesh generation using a set of pre-defined deformation functions. The resulting curved multi-block mesh is composed of of several structured boxes, which are first assembled and then globally mapped to a curved domain.
+
+<dl class="aligned-list">
+    <dt><code>convtest</code>:</dt>
+    <dd>Convergence test mapping. A simple sinusoidal deformation in all directions to test the convergence behavior of high-order methods on curved meshes.</dd>
+    <dt><code>cylinder</code>:</dt>
+    <dd>A cylindrical mapping. The 2D square region is mapped to a cylindrical or toroidal coordinate system.</dd>
+    <dt><code>sphere</code>:</dt>
+    <dd>A spherical mapping. The 3D cubic region is mapped to a spherical coordinate system inside \([-1, 1]^3\).</dd>
+    <dt><code>phill</code>:</dt>
+    <dt>Periodic hill mapping. A 2D mapping to generate an extruded periodic hill geometry.</dt>
+</dl>

--- a/docs/user-guide/parameter-file.md
+++ b/docs/user-guide/parameter-file.md
@@ -1,0 +1,186 @@
+# Parameter File Format
+
+Description of the parameter file format and available options.
+
+---
+
+PyHOPE reads a self-hosting INI-style parameter file. The following documentation is grouped by sections describes the available parameters and their meaning. Parameters not specified in the parameter file are set to default values.
+
+!!! info "General Remarks"
+    - Boolean parameters can be set to `T`/`True` or `F`/`False` (case-insensitive)
+    - Vectors are specified as comma-separated values using Fortran-like notation `(/ ... /)`
+    - Arrays are flattened with each dimension separated by a double comma `,,`, so `(/ ... ,, ... /)`
+
+??? example "Example Help Output"
+    The following file is a complete example of a parameter file with all available options and their default values. The actual parameter file used for mesh generation can omit any parameters that should be set to their default values.
+    ```ini
+    !------------------------------------------------------------------------------
+    ! Common
+    !------------------------------------------------------------------------------
+    nThreads                         =                   10 ! Number of threads for multiprocessing
+    !------------------------------------------------------------------------------
+    ! Output
+    !------------------------------------------------------------------------------
+    ProjectName                      =                      ! Name of output files
+    OutputFormat                     =                 HDF5 ! Mesh output format
+    OutputMetadata                   =                    T ! Mesh output metadata (if supported by OutputFormat)
+    DebugVisu                        =                    F ! Launch the GMSH GUI to visualize the mesh
+    !------------------------------------------------------------------------------
+    ! Mesh
+    !------------------------------------------------------------------------------
+    Mode                             =                      ! Mesh generation mode (1 - Internal, 3 - External [MeshIO])
+    nZones                           =                      ! Number of mesh zones
+    Corner                           =                      ! Corner node positions: (/ x_1,y_1,z_1,, x_2,y_2,z_2,, ... ,, x_8,y_8,z_8/)
+    X0                               =                      ! Origin of a zone. Equivalent to a corner node.
+    DX                               =                      ! Extension of the zone in each spatial direction starting from the origin X0 corner node
+    nElems                           =                      ! Number of elements in each direction
+    ElemType                         =           hexahedron ! Element type
+    EliminateNearDuplicates          =                    T ! Enables elimination of near duplicate points
+    Filename                         =                      ! Name of external mesh file
+    MeshIsAlreadyCurved              =                    F ! Enables mesh agglomeration
+    NGeo                             =                    1 ! Order of spline-reconstruction for curved surfaces
+    BoundaryOrder                    =                    2 ! Order of spline-reconstruction for curved surfaces (legacy)
+    vv                               =                      ! Vector for periodic BC
+    doPeriodicCorrect                =                    F ! Enables periodic correction
+    doSortIJK                        =                    F ! Sort the mesh elements along the I,J,K directions
+    doSplitToHex                     =                    F ! Split simplex elements into hexahedral elements
+    doMortars                        =                    T ! Enables mortars
+    !------------------------------------------------------------------------------
+    ! Boundaries
+    !------------------------------------------------------------------------------
+    BoundaryName                     =                      ! Name of domain boundary
+    BoundaryType                     =                      ! (/ Type, curveIndex, State, alpha /)
+    BCIndex                          =                      ! Index of BC for each boundary face
+    !------------------------------------------------------------------------------
+    ! Mesh Checks
+    !------------------------------------------------------------------------------
+    CheckElemJacobians               =                    T ! Check the Jacobian and scaled Jacobian for each element
+    CheckConnectivity                =                    T ! Check if the side connectivity, including correct flip
+    CheckWatertightness              =                    T ! Check if the mesh is watertight
+    CheckSurfaceNormals              =                    T ! Check if the surface normals point outwards
+    !------------------------------------------------------------------------------
+    ! Transformation
+    !------------------------------------------------------------------------------
+    meshScale                        =                  1.0 ! Scale the mesh
+    meshTrans                        =         (/0.,0.,0./) ! Translate the mesh
+    meshRot                          = (/1.,0.,0.,0.,1.,0.,0.,0.,1./) ! Rotate the mesh around rotation center
+    meshRotCenter                    =         (/0.,0.,0./) ! Rotate the mesh around rotation center
+    MeshPostDeform                   =                 none ! Mesh post-transformation template
+    !------------------------------------------------------------------------------
+    ! Stretching
+    !------------------------------------------------------------------------------
+    StretchType                      =            (/0,0,0/) ! Stretching type for individual zone per spatial direction.
+    Factor                           =                      ! Stretching factor of zone for geometric stretching for each spatial direction.
+    l0                               =                      ! Smallest desired element in zone per spatial direction.
+    DXmaxToDXmin                     =                      ! Ratio between the smallest and largest element per spatial direction
+    !------------------------------------------------------------------------------
+    ! Finite Element Method (FEM) Connectivity
+    !------------------------------------------------------------------------------
+    doFEMConnect                     =                    F ! Generate finite element method (FEM) connectivity
+    ```
+
+## Common
+
+Common parameters for all mesh generation modes.
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `nThreads`                               | int                                | `10`                                  | 0, ≥1                                  | Maximum number of worker threads for multiprocessing. Use the number of physical cores you want active during mesh generation/processing. Set to `0` to disable multiprocessing globally. |
+
+## Output
+
+Output parameter controlling the output file name and format.
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `ProjectName`                            | string                             | —                                     | string                                 | Base name for output files. If omitted, a tool- or input-derived name may be used. |
+| `OutputFormat`                           | int &#124; string                  | `HDF5`                                | `HDF5`, `VTK`, `GMSH` (experimental)   | Mesh output format for the generated mesh. `HDF5` is the native PyHOPE format. `VTK` and `GMSH` are provided as command formats for interoperability with other tools. |
+| `OutputMetadata`                         | bool                               | `T`                                   | `T` &#124; `F`                         | Write mesh metadata in XDMF format when supported by the selected `OutputFormat`.  |
+| `DebugMesh`                              | bool                               | `F`                                   | `T` &#124; `F`                         | Emit an auxiliary VTK mesh for low-order visualization and troubleshooting.        |
+| `DebugVisu`                              | bool                               | `F`                                   | `T` &#124; `F`                         | Launch the Gmsh GUI after mesh generation for interactive validation and spot checks. |
+
+## Mesh
+
+Mesh parameters controlling the respective mesh generation mode.
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `Mode`                                   | int &#124; string                  | —                                    | `1` (internal) &#124; `3` (external)    | Mesh generation mode. `1` builds meshes using the internal mesh generator. `3` reads and converts meshes from external mesh generators. |
+| `NGeo`                                   | int                                | `1`                                   | ≥ 1                                    | Polynomial order used for representation of curved elements. Higher orders improve geometric fidelity. |
+| `BoundaryOrder`                          | int                                | `2`                                   | ≥ 2                                    | Legacy parameter for polynomial order used for representation of curved elements. Prefer `NGeo` where applicable; kept for backward compatibility. |
+| `doSortIJK`                              | bool                               | `F`                                   | `T` &#124; `F`                         | Reorder elements primarily along I, then J, then K instead of the default space-filling Hilbert curve. |
+
+### Internal Mesh Generator (Mode = `1` | `internal`)
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `nZones`                                 | int                                | —                                     | ≥ 1                                    | Number of mesh zones (logical blocks). Multi-zone meshes allow different discretizations or stretching per region. |
+| `Corner`                                 | vector                             | —                                     | `(/ x1,y1,z1,, …,, x8,y8,z8 /)`        | Corner node positions for a mesh block. Provide the eight 3D corner coordinates to define the block extents. |
+| `X0`                                     | vector                             | —                                     | `(/ x, y, z /)`                        | Zone origin (equivalent to first corner node). Must be combined with `DX` to define the zone extents. |
+| `DX`                                     | vector                             | —                                     | `(/ Δx, Δy, Δz /)`                     | Zone extents along each axis. Must be combined with `X0` to define the zone extents. |
+| `nElems`                                 | vector (int)                       | —                                     | `(/ Nx, Ny, Nz /)`                     | Number of elements per axis within the zone. Controls resolution of the transfinite mesh along each direction before stretching/splitting. |
+| `ElemType`                               | string                             | `108`                                 | `104` &#124; `105` &#124; `106` &#124; `108` | Element topology. Hexahedral (`108`) elements are default. Other element types are identified by the number of corner nodes and generated by splitting hexahedral elements. |
+| `StretchType`                            | vector (int)                       | `(/.../)`                             | `(/ Sx, Sy, Sz /)`                     | Stretching scheme per axis. `0` disables stretching; other positive integers select supported schemes (`constant`, `factor`, `ratio`, `combination`). |
+| `Factor`                                 | vector (float)                     | —                                     | `(/ fx, fy, fz /)`                     | Controls element growth/decay per axis for geometric schemes. Values > 1 produce growth; between 0 and 1 produce decay. |
+| `l0`                                     | vector (float)                     | —                                     | `(/ lx, ly, lz /)`                     | Target smallest element size per axis to resolve small-scale near-boundary features. |
+| `DXmaxToDXmin`                           | vector or float                    | —                                     | ratio ≥ 1                              | Ratio between the largest and smallest element sizes per axis. |
+
+### External Mesh Generator (Mode = `3` | `external`)
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `Filename`                               | string                             | —                                     | path                                   | Path to an external mesh when `Mode = 3`. PyHOPE might temporarily convert the mesh to an intermediate format for processing. |
+| `MeshIsAlreadyCurved`                    | bool                               | `F`                                   | `T` &#124; `F`                         | Indicates that the input geometry is curved. Enables mesh agglomeration if `NGeo>1`.
+
+## Boundary Conditions
+
+Parameters controlling boundary conditions and zone interfaces.
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `BoundaryName`                           | string                             | —                                     | identifier                             | Human-readable name for a domain boundary. Use consistent names for BC references when using external meshes. |
+| `BoundaryType`                           | tuple                              | —                                    | `(/ Type, curveIndex, State, alpha /)`  | Boundary condition specification. Must be compatible with the boundary conditions in the DG solver. |
+| `BCIndex`                                | array (int)                        | —                                    | per-face indices                        | Boundary condition index for each boundary face. Must match the block face ordering. |
+| `vv`                                     | vector                             | —                                     | `(/ vx, vy, vz /)`                     | Periodic boundary offset vector. Translates one periodic face to the other to enforce periodic matching. |
+| `doMortars`                              | bool                               | `T`                                   | `T` &#124; `F`                         | Enable mortar interfaces (non-conforming face coupling with hanging nodes) between elements. |
+
+## Transformation
+
+Transform mesh coordinates with translation, rotation, and scaling, or apply a user-defined transformation.
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `meshScale`                              | float                              | `1.0`                                 | > 0                                    | Uniform scaling factor for all coordinates. |
+| `meshTrans`                              | vector                             | `(/.../)`                             | `(/ Δx, Δy, Δz /)`                     | Translation applied for all coordinates. |
+| `meshRot`                                | matrix (3×3)                       | `(/.../)`                             | row-major 9-tuple                      | Rotation matrix applied about `meshRotCenter`. Provide nine values forming an orthonormal rotation matrix. |
+| `meshRotCenter`                          | vector                             | `(/.../)`                             | `(/ x, y, z /)`                        | Pivot point for rotation. Set to the model's logical pivot/centroid to avoid unintended offsets. |
+| `MeshPostDeform`                         | string                             | `none`                                | template name                          | Optional post-transform deformation template applied after scale/translate/rotate. |
+
+## Post-Processing
+
+Post-processing options for mesh cleanup and optimization.
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `EliminateNearDuplicates`                | bool                               | `T`                                   | `T` &#124; `F`                         | Merge nodes closer than an internal tolerance to avoid sliver elements and improve connectivity consistency. |
+| `doPeriodicCorrect`                      | bool                               | `F`                                   | `T` &#124; `F`                         | Apply corrective adjustments for periodic matching after initial pairing. |
+| `doSplitToHex`                           | bool                               | `F`                                   | `T` &#124; `F`                         | Split simplex elements into hexahedra when supported to homogenize element types for hex-only toolchains. |
+
+## Mesh Checks
+
+Perform mesh quality checks and report statistics.
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `CheckElemJacobians`                     | bool                               | `T`                                   | `T` &#124; `F`                         | Compute Jacobian and scaled Jacobian for each element to detect inverted or poorly shaped cells. |
+| `CheckConnectivity`                      | bool                               | `T`                                   | `T` &#124; `F`                         | Verify side connectivity and correct face orientation/flip between adjacent elements to ensure topological consistency. |
+| `CheckWatertightness`                    | bool                               | `T`                                   | `T` &#124; `F`                         | Ensure there are no gaps/holes between connected elements. |
+| `CheckSurfaceNormals`                    | bool                               | `T`                                   | `T` &#124; `F`                         | Confirm surface normals point outward consistently. |
+
+## FEM Connectivity
+
+Create explicit connectivity arrays for finite element method (FEM) solvers that require node/face-to-element connectivity.
+
+| <div style="width:200px">Parameter</div> | <div style="width:90px">Type</div> | <div style="width:50px">Default</div> | <div style="width:200px">Allowed</div> | Explanation                            |
+| ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
+| `doFEMConnect`                           | bool                               | `F`                                   | `T` &#124; `F`                         | Generate FEM connectivity (node/face-to-element). Enable when exporting to FEM solvers that require extended connectivity information. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This file is part of PyHOPE
+#
+# Copyright (c) 2024 Numerics Research Group, University of Stuttgart, Prof. Andrea Beck
+#
+# PyHOPE is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# PyHOPE is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# PyHOPE. If not, see <http://www.gnu.org/licenses/>.
+# ==================================================================================================================================
+# Mesh generation library
+# ==================================================================================================================================
+
+# General settings
+site_name: PyHOPE
+site_url: https://hopr-framework.github.io/PyHOPE
+repo_url: https://github.com/hopr-framework/PyHOPE
+site_description: PyHOPE documentation
+site_author: Numerics Research Group (NRG), University of Stuttgart
+copyright: Copyright &copy; 2025, <a href="https://numericsresearchgroup.org/team.html">Numerics Research Group</a>
+
+# Visual settings
+theme:
+  name: mkdocs
+  user_color_mode_toggle: true
+  locale: en
+  highlightjs: true
+
+# Navigation settings
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - User Guide:
+    - Introduction: user-guide/index.md
+    - Mesh Generators:
+      - Internal: user-guide/mesh-generators/internal.md
+      - External: user-guide/mesh-generators/external.md
+    - Parameter File Format: user-guide/parameter-file.md
+  # - Issue Tracker: 'https://github.com/hopr-framework/PyHOPE/issues'
+  - Mesh Format: mesh-format.md
+  - About:
+    - Authors: 'AUTHORS.md'
+    - Changelog: 'CHANGELOG.md'
+    - License: 'LICENSE.md'
+
+# CSS settings
+extra_css:
+  - css/extra.css
+
+# Plugin settings
+plugins:
+  - search
+  # - autorefs
+
+# Markdown settings
+markdown_extensions:
+  # Footnotes
+  - footnotes
+  # Table of contents (links to headings)
+  - toc:
+      permalink: true
+  # Tables (enabled by default)
+  - tables
+  # Code blocks
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  # Math equations
+  - pymdownx.arithmatex:
+      generic: true
+  # Adminition (callouts)
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,8 @@ markdown_extensions:
   - admonition
   - pymdownx.details
   - pymdownx.superfences
+  # Attribute lists
+  - attr_list
 
 extra_javascript:
   - javascripts/mathjax.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
   - Getting Started: getting-started.md
   - User Guide:
     - Introduction: user-guide/index.md
+    - Installation: user-guide/installation.md
     - Mesh Generators:
       - Internal: user-guide/mesh-generators/internal.md
       - External: user-guide/mesh-generators/external.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ repo_url: https://github.com/hopr-framework/PyHOPE
 site_description: PyHOPE documentation
 site_author: Numerics Research Group (NRG), University of Stuttgart
 copyright: Copyright &copy; 2025, <a href="https://numericsresearchgroup.org/team.html">Numerics Research Group</a>
+edit_uri: ""  # Disable "Edit on GitHub", just link to the repository
 
 # Visual settings
 theme:

--- a/pyhope/check/check_health.py
+++ b/pyhope/check/check_health.py
@@ -310,7 +310,5 @@ def CheckHealth() -> None:
     # Warn if we know that Gmsh uses an outdated CGNS
     if gmshp.strip() != 'NRG':
         print(hopout.warn('Detected Gmsh package uses an outdated CGNS (v3.4). ' +
-                          'For compatibility, replace with the updated NRG version',
-                          prefix=f'├── {hopout.Symbols.WARN} ',
-                          warnonce=True))
+                          'For compatibility, replace with the updated NRG version'))
     DependencyHealth('ParaView', version=DependencyVersion('paraview'), info=' (optional)')

--- a/pyhope/check/check_install.py
+++ b/pyhope/check/check_install.py
@@ -235,6 +235,7 @@ def CheckInstall(path: Optional[str] = None) -> None:
         tmpDir = tempfile.TemporaryDirectory(delete=False)  # pyright: ignore[reportCallIssue]
         downloadGitDir('hopr-framework', 'PyHOPE', testDir, tmpDir.name, token)
         path = tmpDir.name
+        hopout.sep()
 
     # Final check, are there tutorials at the given path
     if not path:

--- a/pyhope/check/check_install.py
+++ b/pyhope/check/check_install.py
@@ -307,18 +307,18 @@ def CheckInstall(path: Optional[str] = None) -> None:
                 #     p.terminate()
             except subprocess.CalledProcessError as exc:
                 tsuccess[tNum] = False
-                hopout.routine(f'{hopout.Symbols.ERR } PyHOPE failed for "{tutorial}": ' +
+                hopout.info(f'{hopout.Symbols.ERR } PyHOPE failed for "{tutorial}": ' +
                                f'Return code = {getattr(exc, "returncode", "")}')
                 bar.step()
                 continue
             except subprocess.TimeoutExpired:
                 tsuccess[tNum] = False
-                hopout.routine(f'{hopout.Symbols.ERR } PyHOPE timed out for "{tutorial}"')
+                hopout.info(f'{hopout.Symbols.ERR } PyHOPE timed out for "{tutorial}"')
                 bar.step()
                 continue
             except Exception as exc:
                 tsuccess[tNum] = False
-                hopout.routine(f'{hopout.Symbols.ERR } Unexpected error running PyHOPE for "{tutorial}": {exc}')
+                hopout.info(f'{hopout.Symbols.ERR } Unexpected error running PyHOPE for "{tutorial}": {exc}')
                 bar.step()
                 continue
 
@@ -326,7 +326,7 @@ def CheckInstall(path: Optional[str] = None) -> None:
             if not os.path.isfile(os.path.join(tutorialPath, f'{projectName}_mesh.h5')):
                 # raise ExecError(f'PyHOPE failed to generate mesh for {tutorial}')
                 tsuccess[tNum] = False
-                hopout.routine(f'{hopout.Symbols.ERR } PyHOPE did not produce {projectName}_mesh.h5 for "{tutorial}"')
+                hopout.info(f'{hopout.Symbols.ERR } PyHOPE did not produce {projectName}_mesh.h5 for "{tutorial}"')
                 bar.step()
                 continue
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 [project.urls]
 homepage = "https://numericsresearchgroup.org"
 repository = "https://github.com/hopr-framework/pyhope"
-documentation = "https://hopr.readthedocs.io"
+documentation = "https://hopr-framework.github.io/PyHOPE"
 
 [project.scripts]
 pyhope = "pyhope.script.pyhope_cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     'plotext',
     'scipy',
     'gmsh',
-    'sortedcontainers',
+    # 'sortedcontainers',
     'typing-extensions'
 ]
 keywords = ["PyHOPE", "mesh generator"]


### PR DESCRIPTION
Add documentation and deploy to GitHub pages. Loosely based on HOPR documentation but adopted to PyHOPE and significantly shortened.

```bash
pip install install mkdocs-material mkdocs-autorefs
mkdocs serve
```