### PR TITLE
Feature: XDMF Debugmesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ $ pyhope tutorials/1-01-cartbox/parameter.ini
 │ INIT OUTPUT...
 │                     ProjectName │ 1-01-cartbox                    │ *CUSTOM │
 │                    OutputFormat │ 0 [HDF5]                        │ *CUSTOM │
-│                  OutputMetadata │ True                            │ DEFAULT │
 │                       DebugMesh │ T                               │ *CUSTOM │
 │                       DebugVisu │ F                               │ *CUSTOM │
 ├─────────────────────────────────────────────
@@ -169,10 +168,7 @@ $ pyhope tutorials/1-01-cartbox/parameter.ini
 │         Curved Hexahedra  :          512
 ├────
 ├── Writing HDF5 mesh to "1-01-cartbox_mesh.h5"
-│  WARNING  ┃ XDMF only supports linear/quadratic elements, skipping...
-├────
-├── Writing volume  debug mesh to "1-01-cartbox_DebugElem.vtu"
-├── Writing surface debug mesh to "1-01-cartbox_DebugSide.vtu"
+├── Writing XDMF mesh to "1-01-cartbox_DebugMesh.xdmf"
 ┢━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ┃ PyHOPE completed in [0.25 sec]
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/docs/user-guide/parameter-file.md
+++ b/docs/user-guide/parameter-file.md
@@ -23,7 +23,6 @@ PyHOPE reads a self-hosting INI-style parameter file. The following documentatio
     !------------------------------------------------------------------------------
     ProjectName                      =                      ! Name of output files
     OutputFormat                     =                 HDF5 ! Mesh output format
-    OutputMetadata                   =                    T ! Mesh output metadata (if supported by OutputFormat)
     DebugVisu                        =                    F ! Launch the GMSH GUI to visualize the mesh
     !------------------------------------------------------------------------------
     ! Mesh
@@ -95,8 +94,7 @@ Output parameter controlling the output file name and format.
 | ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
 | `ProjectName`                            | string                             | —                                     | string                                 | Base name for output files. If omitted, a tool- or input-derived name may be used. |
 | `OutputFormat`                           | int &#124; string                  | `HDF5`                                | `HDF5`, `VTK`, `GMSH` (experimental)   | Mesh output format for the generated mesh. `HDF5` is the native PyHOPE format. `VTK` and `GMSH` are provided as output formats for interoperability with other tools. |
-| `OutputMetadata`                         | bool                               | `T`                                   | `T` &#124; `F`                         | Write mesh metadata in XDMF format when supported by the selected `OutputFormat`.  |
-| `DebugMesh`                              | bool                               | `F`                                   | `T` &#124; `F`                         | Emit an auxiliary VTK mesh for low-order visualization and troubleshooting.        |
+| `DebugMesh`                              | bool                               | `F`                                   | `T` &#124; `F`                         | Emit an auxiliary XDMF mesh for low-order visualization and troubleshooting.         |
 | `DebugVisu`                              | bool                               | `F`                                   | `T` &#124; `F`                         | Launch the Gmsh GUI after mesh generation for interactive validation and spot checks. |
 
 ## Mesh

--- a/pyhope/io/io.py
+++ b/pyhope/io/io.py
@@ -26,7 +26,7 @@
 # Standard libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
 from collections import defaultdict
-from typing import Final, Tuple, cast
+from typing import Final, cast
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 import h5py
@@ -53,8 +53,7 @@ def DefineIO() -> None:
     CreateIntOption(    'OutputFormat'  , number=MeshFormat.FORMAT_HDF5, name='HDF5')
     CreateIntOption(    'OutputFormat'  , number=MeshFormat.FORMAT_VTK , name='VTK')
     CreateIntOption(    'OutputFormat'  , number=MeshFormat.FORMAT_GMSH, name='GMSH')
-    CreateLogical(      'OutputMetadata', default=True  , help='Mesh output metadata (if supported by OutputFormat)')  # noqa: E271
-    CreateLogical(      'DebugMesh'     , default=False , help='Mesh output debug mesh in VTK format')
+    CreateLogical(      'DebugMesh'     , default=False , help='Output debug mesh in XDMF format')
     CreateLogical(      'DebugVisu'     , default=False , help='Launch the GMSH GUI to visualize the mesh')
 
 
@@ -70,7 +69,6 @@ def InitIO() -> None:
 
     io_vars.projectname  = GetStr('ProjectName')
     io_vars.outputformat = GetIntFromStr('OutputFormat')
-    io_vars.outputmeta   = GetLogical('OutputMetadata')
 
     io_vars.debugmesh    = GetLogical('DebugMesh')
     io_vars.debugvisu    = GetLogical('DebugVisu')
@@ -85,7 +83,6 @@ def IO() -> None:
     import pyhope.output.output as hopout
     from pyhope.common.common_vars import Common
     from pyhope.io.io_debug import DebugIO
-    from pyhope.io.io_xdmf import xdmfCreate
     from pyhope.io.io_vars import MeshFormat, ELEM, ELEMTYPE
     # ------------------------------------------------------
 
@@ -110,7 +107,6 @@ def IO() -> None:
             fname = '{}_mesh.h5'.format(pname)
 
             elemInfo, sideInfo, nodeInfo, nodeCoords, \
-            xdmfConnect, \
             FEMElemInfo, vertexInfo, vertexConnectInfo, edgeInfo, edgeConnectInto, \
             elemCounter = getMeshInfo()
 
@@ -142,10 +138,6 @@ def IO() -> None:
                 _ = f.create_dataset('SideInfo'     , data=sideInfo)
                 _ = f.create_dataset('GlobalNodeIDs', data=nodeInfo)
                 _ = f.create_dataset('NodeCoords'   , data=nodeCoords)
-
-                # XDMF format
-                if io_vars.outputmeta:
-                    xdmfCreate(f, elemInfo, xdmfConnect)
 
                 if FEMElemInfo is not None:
                     f.attrs['FEMconnect'] = 'ON'
@@ -216,7 +208,6 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
                            np.ndarray,         # SideInfo
                            np.ndarray,         # NodeInfo
                            np.ndarray,         # NodeCoords
-                           Tuple,              # XDMF connectivity
                            np.ndarray | None,  # Optional[FEMElemInfo]
                            np.ndarray | None,  # Optional[VertexInfo]
                            np.ndarray | None,  # Optional[VertexConnectInfo]
@@ -379,19 +370,13 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
     nodeInfo   = np.zeros((nNodes)   , dtype=np.int32)
     nodeCoords = np.zeros((nNodes, 3), dtype=np.float64)
 
-    # Fill the XDMF connectivity
-    elemTypes   = np.unique(elemInfo[:, 0])
-    xdmfconnect = tuple([list() for _ in range(len(elemTypes))])
-
     # Pre-compute LINTEN mappings for all element types
-    linCache    = {}
+    elemTypes = np.unique(elemInfo[:, 0])
+    linCache  = {}
     for elemType in elemTypes:
         _, mapLin = LINTEN(elemType, order=mesh_vars.nGeo)
         mapLin    = np.array(tuple(mapLin[np.int64(i)] for i in range(len(mapLin))))
         linCache[elemType] = mapLin
-
-    # Pre-compute the index mapping
-    elemTypeIndexMap = {elemType: i for i, elemType in enumerate(elemTypes)}
 
     # Calculate the NodeInfo
     nodeCount  = 0
@@ -404,10 +389,6 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
         nElemNodes = elemNodes.size
         indices    = nodeCount + mapLin[:nElemNodes]
 
-        # Assign the indices to XDMF
-        elemTypeID = elemTypeIndexMap[elemType]
-        xdmfconnect[elemTypeID].append(indices)
-
         # Assign nodeInfo and nodeCoords in vectorized fashion
         nodeInfo[  indices] = elemNodes + 1
         nodeCoords[indices] = points[elemNodes]
@@ -419,10 +400,6 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
     else:
         FEMElemInfo = vertexInfo = vertexConnectInfo = edgeInfo = edgeConnectInfo = None
 
-    # Convert XDMF to numpy array
-    # xdmfconnect = np.array(xdmfconnect, dtype=np.int32)
-
     return elemInfo, sideInfo, nodeInfo, nodeCoords, \
-           xdmfconnect, \
            FEMElemInfo, vertexInfo, vertexConnectInfo, edgeInfo, edgeConnectInfo, \
            elemCounter

--- a/pyhope/io/io_debug.py
+++ b/pyhope/io/io_debug.py
@@ -39,6 +39,9 @@ import numpy.typing as npt
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Local definitions
 # ----------------------------------------------------------------------------------------------------------------------------------
+# Monkey-patching meshio.xdmf.main.XdmfWriter
+from pyhope.io.io_xdmf import XdmfWriterInit
+meshio.xdmf.main.XdmfWriter.__init__ = XdmfWriterInit  # pyright: ignore[reportAttributeAccessIssue]
 # ==================================================================================================================================
 
 
@@ -80,10 +83,11 @@ def DebugIO() -> None:
     import pyhope.io.io_vars as io_vars
     import pyhope.mesh.mesh_vars as mesh_vars
     import pyhope.output.output as hopout
+    from pyhope.mesh.mesh_common import edges as ELEMEDGES
     from pyhope.mesh.mesh_vars import ELEMTYPE
     # ------------------------------------------------------
 
-    hopout.sep()
+    # hopout.sep()
 
     mesh   : Final             = mesh_vars.mesh
     mpoints: Final[np.ndarray] = mesh.points
@@ -99,6 +103,7 @@ def DebugIO() -> None:
     sides     = {}
     sidetypes = set()
     nodes     = {}
+    edges     = {}
 
     # Instantiate ELEMTYPE
     elemTypeClass = ELEMTYPE()
@@ -143,6 +148,7 @@ def DebugIO() -> None:
         sides.setdefault(st, [])
     if hasFEM:
         nodes.setdefault('vertex', [])
+        edges.setdefault('line'  , [])
 
     # Create ordered mapping from first-order elems to high-order elems
     types  = list(elemtypes)
@@ -165,7 +171,12 @@ def DebugIO() -> None:
                                 }
 
     nodedata: dict[str, list] = {}
+    edgedata: dict[str, list] = {}
     if hasFEM:
+        edgedata.update(                       {'FEMEdgeID'  : [],
+                                                'LocEdge'    : [],
+                                               })
+        # Fully create the nodes here
         nodes = cast(dict[str, npt.ArrayLike], {'vertex':      [np.asarray([s])  for s in range(len(pMap))]})  # noqa: E272
         nodedata.update(                       {'FEMVertexID': [-1 for _ in range(len(pMap))],
                                                })
@@ -216,33 +227,50 @@ def DebugIO() -> None:
                 # Add the nodeData
                 nodedata['FEMVertexID'][node] = melem.vertexInfo[locNode][0]  # pyright: ignore[reportPossiblyUnboundVariable]
 
+            # Create the FEM edges
+            elemEdges = ELEMEDGES(elemType)
+            for edge in elemEdges:
+                # Add the edge
+                edgeInfo  = melem.edgeInfo[edge]
+                edgeNodes = np.fromiter((pInv[s] for s in edgeInfo[3]), dtype=np.int64)
+                edges['line'].append(edgeNodes)
+
+                edgedata['FEMEdgeID'  ].append(edgeInfo[1])
+                edgedata['LocEdge'    ].append(edgeInfo[0])
+
     # Update points to unique first-order coords
     coords = mpoints[pMap]
     # Find the mapping from the cell keys to the elemtypes
-    elemOrder = [tInv[cb] for cb in list(elems.keys())]
+    elemOrder = [tInv[cb] for cb in elems.keys()]
 
     # Ensure cell_data lists are aligned to the actual cell block order used by meshio.Mesh
     elemdata = {k: [np.asarray(v[idx]) for idx in elemOrder] for k, v in elemdata.items()}
+    eleminfo = {'name': 'Volume'}
     # Clean-up for memory safety
     del elemOrder
+
+    # Create the output list
+    debugOut   = []
 
     # Create the final debugElem with first-order elements
     debugElem  = meshio.Mesh(points    = coords,     # noqa: E251
                              cells     = elems,      # noqa: E251
                              cell_data = elemdata,   # noqa: E251
+                             info      = eleminfo,   # noqa: E251
                             )
-    fname = f'{pname}_DebugElem.vtu'
-    hopout.routine(f'Writing volume  debug mesh to "{fname}"')
-    debugElem.write(fname)
-    # Clean-up for memory safety
-    del debugElem
-    del fname
+    debugOut.append(debugElem)
+    # fname = f'{pname}_Debug.xdmf'
+    # hopout.routine(f'Writing volume  debug mesh to "{fname}"')
+    # debugElem.write(fname)
+    # # Clean-up for memory safety
+    # del debugElem
 
     # Find the mapping from the side keys to the elemtypes
-    sideOrder = [sInv[cb] for cb in list(sides.keys())]
+    sideOrder = [sInv[cb] for cb in sides.keys()]
 
     # Ensure cell_data lists are aligned to the actual cell block order used by meshio.Mesh
     sidedata = {k: [np.asarray(v[idx]) for idx in sideOrder] for k, v in sidedata.items()}
+    sideinfo = {'name': 'Surface'}
     # Clean-up for memory safety
     del sideOrder
 
@@ -250,28 +278,54 @@ def DebugIO() -> None:
     debugSide  = meshio.Mesh(points    = coords,     # noqa: E251
                              cells     = sides,      # noqa: E251
                              cell_data = sidedata,   # noqa: E251
+                             info      = sideinfo,   # noqa: E251
                             )
-    fname = f'{pname}_DebugSide.vtu'
-    hopout.routine(f'Writing surface debug mesh to "{fname}"')
-    debugSide.write(fname)
-    # Clean-up for memory safety
-    del debugSide
-    del fname
-
-    # Ensure cell_data lists are aligned to the actual cell block order used by meshio.Mesh
-    nodedata = {k: [np.asarray(v)] for k, v in nodedata.items()}
+    debugOut.append(debugSide)
+    # fname = f'{pname}_Debug.xdmf'
+    # hopout.routine(f'Writing surface debug mesh to "{fname}"')
+    # debugSide.write(fname)
+    # # Clean-up for memory safety
+    # del debugSide
+    # del fname
 
     if hasFEM:
+        # Ensure cell_data lists are aligned to the actual cell block order used by meshio.Mesh
+        edgedata = {k: [np.asarray(v)] for k, v in edgedata.items()}
+        edgeinfo = {'name': 'FEMEdges'}
+
+        debugEdge  = meshio.Mesh(points    = coords,     # noqa: E251
+                                 cells     = edges,      # noqa: E251
+                                 cell_data = edgedata,   # noqa: E251
+                                 info      = edgeinfo,   # noqa: E251
+                                )
+        debugOut.append(debugEdge)
+        # fname = f'{pname}_DebugEdge.vtu'
+        # hopout.routine(f'Writing edge    debug mesh to "{fname}"')
+        # debugNode.write(fname)
+        # # Clean-up for memory safety
+        # del debugEdge
+        # del fname
+
+        # Ensure cell_data lists are aligned to the actual cell block order used by meshio.Mesh
+        nodedata = {k: [np.asarray(v)] for k, v in nodedata.items()}
+        nodeinfo = {'name': 'FEMVertices'}
+
         debugNode  = meshio.Mesh(points    = coords,     # noqa: E251
                                  cells     = nodes,      # noqa: E251
                                  cell_data = nodedata,   # noqa: E251
+                                 info      = nodeinfo,   # noqa: E251
                                 )
-        fname = f'{pname}_DebugNode.vtu'
-        hopout.routine(f'Writing vertex  debug mesh to "{fname}"')
-        debugNode.write(fname)
-        # Clean-up for memory safety
-        del debugNode
-        del fname
+        debugOut.append(debugNode)
+        # fname = f'{pname}_DebugNode.vtu'
+        # hopout.routine(f'Writing vertex  debug mesh to "{fname}"')
+        # debugNode.write(fname)
+        # # Clean-up for memory safety
+        # del debugNode
+        # del fname
+
+    fname = f'{pname}_DebugMesh.xdmf'
+    hopout.routine(f'Writing XDMF mesh to "{fname}"')
+    meshio.xdmf.main.XdmfWriter(fname, debugOut)
 
     # (Optional:) Write wrapper for multiblock file
     # blocks = [(0, 'VolumeMesh' , f'{pname}_DebugElem.vtu'),

--- a/pyhope/io/io_vars.py
+++ b/pyhope/io/io_vars.py
@@ -39,7 +39,6 @@ from functools import cache
 # ==================================================================================================================================
 projectname  : str                               # Name of output files
 outputformat : int                               # Mesh output format
-outputmeta   : bool                              # Mesh output metadata (optional)
 
 debugmesh    : bool                              # Mesh output debug mesh
 debugvisu    : bool                              # Enable and show debug output / visualization

--- a/pyhope/io/io_xdmf.py
+++ b/pyhope/io/io_xdmf.py
@@ -25,13 +25,16 @@
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Standard libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
-import os
-from functools import cache
+import pathlib
+from typing import Union
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
 import h5py
-import numpy as np
+from meshio import Mesh
+from meshio._common import write_xml
+from meshio._exceptions import WriteError
+from xml.etree import ElementTree as ET
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Local imports
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -41,150 +44,203 @@ import numpy as np
 # ==================================================================================================================================
 
 
-@cache
-def xdmfElems(elemType: int, nGeo: int) -> tuple[str, int]:
-    """ XDMF: Get the element type from the HOPR format
-    - Linear
-        - Polyvertex - a group of unconnected points
-        - Polyline - a group of line segments
-        - Polygon
-        - Triangle
-        - Quadrilateral
-        - Tetrahedron
-        - Pyramid
-        - Wedge
-        - Hexahedron
-    - Quadratic
-        - Edge_3 - Quadratic line with 3 nodes
-        - Tri_6
-        - Quad_8
-        - Tet_10
-        - Pyramid_13
-        - Wedge_15
-        - Hex_20
-    - Arbitrary
-        - 1 - POLYVERTEX
-        - 2 - POLYLINE
-        - 3 - POLYGON
-        - 4 - TRIANGLE
-        - 5 - QUADRILATERAL
-        - 6 - TETRAHEDRON
-        - 7 - PYRAMID
-        - 8 - WEDGE
-        - 9 - HEXAHEDRON
-        - 16 - POLYHEDRON
-        - 34 - EDGE_3
-        - 35 - QUADRILATERAL_9
-        - 36 - TRIANGLE_6
-        - 37 - QUADRILATERAL_8
-        - 38 - TETRAHEDRON_10
-        - 39 - PYRAMID_13
-        - 40 - WEDGE_15
-        - 41 - WEDGE_18
-        - 48 - HEXAHEDRON_20
-        - 49 - HEXAHEDRON_24
-        - 50 - HEXAHEDRON_27
-    """
-    elem_map = { 4: 'TETRAHEDRON',
-                 5: 'PYRAMID',
-                 6: 'WEDGE',
-                 8: 'HEXAHEDRON'
-               }
+# Monkey-patching meshio.xdmf.main.XdmfWriter
+# > We want to be able to write multiple grids into the same HDF5 file
+def XdmfWriterInit(self,
+                   filename        : str,
+                   meshes          : Union[Mesh, list[Mesh]],
+                   data_format     : str = 'HDF',
+                   compression     : str = 'gzip',
+                   compression_opts: int = 4) -> None:
 
-    if elemType % 10 not in elem_map:
-        raise ValueError(f'Error in face_to_edge: elemType {elemType} is not supported')
+    if data_format not in ['XML', 'Binary', 'HDF']:
+        raise WriteError(f'Unknown XDMF data format "{data_format}" (use "XML", "Binary", or "HDF")')
 
-    match elemType % 10:
-        case 4:  # Tetrahedron
-            ndofs = np.floor((nGeo+1)*(nGeo+2)*(nGeo+3  )/6).astype(int)
-        case 5:  # Pyramid
-            ndofs = np.floor((nGeo+1)*(nGeo+2)*(2*nGeo+3)/6).astype(int)
-        case 6:  # Prism / Wedge
-            ndofs = np.floor((nGeo+1)**2      *(nGeo+2  )/2).astype(int)
-        case 8:  # Hexahedron
-            ndofs = (nGeo+1)**3
-        case _:
-            raise ValueError('Unknown element type')
+    self.filename         = pathlib.Path(filename)
+    self.data_format      = data_format
+    self.data_counter     = 0
+    self.compression      = compression
+    self.compression_opts = None if compression is None else compression_opts
 
-    if nGeo == 1:
-        return elem_map[elemType % 10]                , int(ndofs)
-    else:
+    if data_format == 'HDF':
+        self.h5_filename = self.filename.with_suffix('.h5')
+        self.h5_file     = h5py.File(self.h5_filename, 'w')
 
-        return elem_map[elemType % 10] + f'_{ndofs:d}', int(ndofs)
+    # Create the XDMF file base
+    xdmf_file = ET.Element('Xdmf', Version='3.0')
+
+    # Create one domain but multiple grids
+    domain = ET.SubElement(xdmf_file, 'Domain')
+    # grid   = ET.SubElement(domain   , 'Grid'  , Name='Grid')
+
+    # Convert a singular mesh to a list, so we can loop
+    if not isinstance(meshes, (list, tuple)):
+        meshes = [meshes]
+
+    for mesh in meshes:
+        # Assign the correct subgrid name
+        if mesh.info is not None and 'name' in mesh.info.keys():
+            gridname = mesh.info['name']
+        else:
+            gridname = 'Grid'
+
+        grid = ET.SubElement(domain, 'Grid', Name=gridname)
+
+        self.write_points(    grid           , mesh.points)
+        # self.field_data(      mesh.field_data, information)
+        self.write_cells(     mesh.cells     , grid)
+        self.write_point_data(mesh.point_data, grid)
+        self.write_cell_data( mesh.cell_data , grid)
+
+        ET.register_namespace('xi', 'https://www.w3.org/2001/XInclude/')
+
+        write_xml(filename, xdmf_file)
 
 
-def xdmfCreate(f:           h5py.File,
-               ElemInfo:    np.ndarray,
-               xdmfConnect: tuple[list[int]]) -> None:
-    # Local imports ----------------------------------------
-    import pyhope.output.output as hopout
-    from pyhope.mesh.mesh_vars import nGeo
-    # ------------------------------------------------------
-
-    # Currently, only first/second order is supported by XDMF
-    if nGeo > 2:
-        print(hopout.warn('XDMF only supports linear/quadratic elements, skipping...'))
-        return None
-
-    hname = f.filename
-    h5nam, _ = os.path.splitext(hname)
-    fname = '{}.xmf'.format(h5nam)
-
-    # Start assembling the XDMF data
-    xdmf = [
-        '<?xml version="1.0" ?>',
-        '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" >',
-        '<Xdmf Version="2.0">',
-        '  <Domain>',
-        '    <Grid Name="Mesh" GridType="Collection" CollectionType="Spatial">'
-    ]
-
-    # Find number of unique element types
-    elemTypes  = np.unique(ElemInfo[:, 0])
-    nElemTypes = np.zeros(elemTypes.size, dtype=int)
-
-    # Currently, pyramids are only supported with first order
-    if any(elemTypes % 10 == 5) and nGeo > 1:
-        print(hopout.warn('XDMF only supports linear pyramidal elements, skipping...'))
-        return None
-
-    # Count the number of elements per type
-    for elem in ElemInfo:
-        elemType = np.where(elemTypes == elem[0])
-        nElemTypes[elemType] += 1
-
-    # Create the arrays for each dataset
-    for elemNum, elemType in enumerate(elemTypes):
-        nElems          = nElemTypes[elemNum]
-        elemName, nDofs = xdmfElems(elemType, nGeo)
-        nNodes          = nElems*nDofs
-
-        xdmf += [
-            f'      <Grid Name="{elemName}" GridType="Uniform">',
-            f'        <Topology TopologyType="{elemName}" NumberOfElements="{nElems}">',
-            f'          <DataItem Format="HDF" Dimensions="{nElems} {nDofs}" NumberType="Int" Precision="4">',
-            f'            {hname}:/ElemConnectivity{elemName}',
-            '           </DataItem>',
-            '         </Topology>',
-            '        <Geometry GeometryType="XYZ">',
-            f'          <DataItem Format="HDF" Dimensions="{nNodes} 3" NumberType="Float" Precision="8">',
-            f'            {hname}:/NodeCoords',
-            '           </DataItem>',
-            '        </Geometry>',
-            '      </Grid>'
-        ]
-
-        # Write the data to the HDF5 file
-        _ = f.create_dataset(f'ElemConnectivity{elemName}'   , data=np.array(xdmfConnect[elemNum], dtype=int))
-
-    xdmf += [
-        '    </Grid>',
-        '  </Domain>',
-        '</Xdmf>'
-    ]
-
-    hopout.routine('Writing XDMF data to "{}"'.format(fname))
-
-    # Write the XDMF file
-    with open(fname, 'w') as x:
-        x.write('\n'.join(xdmf))
+# @cache
+# def xdmfElems(elemType: int, nGeo: int) -> tuple[str, int]:
+#     """ XDMF: Get the element type from the HOPR format
+#     - Linear
+#         - Polyvertex - a group of unconnected points
+#         - Polyline - a group of line segments
+#         - Polygon
+#         - Triangle
+#         - Quadrilateral
+#         - Tetrahedron
+#         - Pyramid
+#         - Wedge
+#         - Hexahedron
+#     - Quadratic
+#         - Edge_3 - Quadratic line with 3 nodes
+#         - Tri_6
+#         - Quad_8
+#         - Tet_10
+#         - Pyramid_13
+#         - Wedge_15
+#         - Hex_20
+#     - Arbitrary
+#         - 1 - POLYVERTEX
+#         - 2 - POLYLINE
+#         - 3 - POLYGON
+#         - 4 - TRIANGLE
+#         - 5 - QUADRILATERAL
+#         - 6 - TETRAHEDRON
+#         - 7 - PYRAMID
+#         - 8 - WEDGE
+#         - 9 - HEXAHEDRON
+#         - 16 - POLYHEDRON
+#         - 34 - EDGE_3
+#         - 35 - QUADRILATERAL_9
+#         - 36 - TRIANGLE_6
+#         - 37 - QUADRILATERAL_8
+#         - 38 - TETRAHEDRON_10
+#         - 39 - PYRAMID_13
+#         - 40 - WEDGE_15
+#         - 41 - WEDGE_18
+#         - 48 - HEXAHEDRON_20
+#         - 49 - HEXAHEDRON_24
+#         - 50 - HEXAHEDRON_27
+#     """
+#     elem_map = { 4: 'TETRAHEDRON',
+#                  5: 'PYRAMID',
+#                  6: 'WEDGE',
+#                  8: 'HEXAHEDRON'
+#                }
+#
+#     if elemType % 10 not in elem_map:
+#         raise ValueError(f'Error in face_to_edge: elemType {elemType} is not supported')
+#
+#     match elemType % 10:
+#         case 4:  # Tetrahedron
+#             ndofs = np.floor((nGeo+1)*(nGeo+2)*(nGeo+3  )/6).astype(int)
+#         case 5:  # Pyramid
+#             ndofs = np.floor((nGeo+1)*(nGeo+2)*(2*nGeo+3)/6).astype(int)
+#         case 6:  # Prism / Wedge
+#             ndofs = np.floor((nGeo+1)**2      *(nGeo+2  )/2).astype(int)
+#         case 8:  # Hexahedron
+#             ndofs = (nGeo+1)**3
+#         case _:
+#             raise ValueError('Unknown element type')
+#
+#     if nGeo == 1:
+#         return elem_map[elemType % 10]                , int(ndofs)
+#     else:
+#
+#         return elem_map[elemType % 10] + f'_{ndofs:d}', int(ndofs)
+#
+#
+# def xdmfCreate(f:           h5py.File,
+#                ElemInfo:    np.ndarray,
+#                xdmfConnect: tuple[list[int]]) -> None:
+#     # Local imports ----------------------------------------
+#     import pyhope.output.output as hopout
+#     from pyhope.mesh.mesh_vars import nGeo
+#     # ------------------------------------------------------
+#
+#     # Currently, only first/second order is supported by XDMF
+#     if nGeo > 2:
+#         print(hopout.warn('XDMF only supports linear/quadratic elements, skipping...'))
+#         return None
+#
+#     hname = f.filename
+#     h5nam, _ = os.path.splitext(hname)
+#     fname = '{}.xmf'.format(h5nam)
+#
+#     # Start assembling the XDMF data
+#     xdmf = [
+#         '<?xml version="1.0" ?>',
+#         '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" >',
+#         '<Xdmf Version="2.0">',
+#         '  <Domain>',
+#         '    <Grid Name="Mesh" GridType="Collection" CollectionType="Spatial">'
+#     ]
+#
+#     # Find number of unique element types
+#     elemTypes  = np.unique(ElemInfo[:, 0])
+#     nElemTypes = np.zeros(elemTypes.size, dtype=int)
+#
+#     # Currently, pyramids are only supported with first order
+#     if any(elemTypes % 10 == 5) and nGeo > 1:
+#         print(hopout.warn('XDMF only supports linear pyramidal elements, skipping...'))
+#         return None
+#
+#     # Count the number of elements per type
+#     for elem in ElemInfo:
+#         elemType = np.where(elemTypes == elem[0])
+#         nElemTypes[elemType] += 1
+#
+#     # Create the arrays for each dataset
+#     for elemNum, elemType in enumerate(elemTypes):
+#         nElems          = nElemTypes[elemNum]
+#         elemName, nDofs = xdmfElems(elemType, nGeo)
+#         nNodes          = nElems*nDofs
+#
+#         xdmf += [
+#             f'      <Grid Name="{elemName}" GridType="Uniform">',
+#             f'        <Topology TopologyType="{elemName}" NumberOfElements="{nElems}">',
+#             f'          <DataItem Format="HDF" Dimensions="{nElems} {nDofs}" NumberType="Int" Precision="4">',
+#             f'            {hname}:/ElemConnectivity{elemName}',
+#             '           </DataItem>',
+#             '         </Topology>',
+#             '        <Geometry GeometryType="XYZ">',
+#             f'          <DataItem Format="HDF" Dimensions="{nNodes} 3" NumberType="Float" Precision="8">',
+#             f'            {hname}:/NodeCoords',
+#             '           </DataItem>',
+#             '        </Geometry>',
+#             '      </Grid>'
+#         ]
+#
+#         # Write the data to the HDF5 file
+#         _ = f.create_dataset(f'ElemConnectivity{elemName}'   , data=np.array(xdmfConnect[elemNum], dtype=int))
+#
+#     xdmf += [
+#         '    </Grid>',
+#         '  </Domain>',
+#         '</Xdmf>'
+#     ]
+#
+#     hopout.routine('Writing XDMF data to "{}"'.format(fname))
+#
+#     # Write the XDMF file
+#     with open(fname, 'w') as x:
+#         x.write('\n'.join(xdmf))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,5 +151,7 @@ ignore_names = [
     "Basis",
     # Exclude debug function
     "time_function",
-               ]
+    # Exclude monkey-patching meshio
+    "__init__", "data_counter", "h5_file"
+    ]
 sort_by_size = true

--- a/tutorials/1-02-cartbox_periodic/parameter.ini
+++ b/tutorials/1-02-cartbox_periodic/parameter.ini
@@ -4,7 +4,7 @@
 ProjectName  = 1-02-cartbox_periodic                ! Name of output files
 DebugVisu    = F                                    ! Launch the GMSH GUI to visualize the mesh
 OutputFormat = HDF5                                 ! Mesh output format (HDF5 VTK)
-OutputMetadata = T                                  ! Mesh output metadata (if supported by OutputFormat)
+DebugMesh    = T                                    ! Output debug mesh in XDMF format
 ! nThreads     = 4                                    ! Number of threads for multiprocessing
 
 !================================================================================================================================= !


### PR DESCRIPTION
Implement debug mesh as low-order XDMF mesh. This way, PyHOPE store all information in a single HDF5 file and reference the different grids via the light data information. This also allows removing the XDMF data from the original mesh.