### PR TITLE
Bugfix: Add missing IJK arrays

### DIFF
--- a/pyhope/io/io.py
+++ b/pyhope/io/io.py
@@ -106,7 +106,7 @@ def IO() -> None:
 
             fname = '{}_mesh.h5'.format(pname)
 
-            elemInfo, sideInfo, nodeInfo, nodeCoords, \
+            elemInfo, elemIJK, sideInfo, nodeInfo, nodeCoords, \
             FEMElemInfo, vertexInfo, vertexConnectInfo, edgeInfo, edgeConnectInto, \
             elemCounter = getMeshInfo()
 
@@ -138,6 +138,10 @@ def IO() -> None:
                 _ = f.create_dataset('SideInfo'     , data=sideInfo)
                 _ = f.create_dataset('GlobalNodeIDs', data=nodeInfo)
                 _ = f.create_dataset('NodeCoords'   , data=nodeCoords)
+
+                if elemIJK     is not None:  # noqa: E272
+                    _ = f.create_dataset('nElems_IJK'        , data=mesh_vars.nElemsIJK)
+                    _ = f.create_dataset('Elem_IJK'          , data=elemIJK)
 
                 if FEMElemInfo is not None:
                     f.attrs['FEMconnect'] = 'ON'
@@ -205,6 +209,7 @@ def IO() -> None:
 
 
 def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
+                           np.ndarray | None,  # ElemIJK
                            np.ndarray,         # SideInfo
                            np.ndarray,         # NodeInfo
                            np.ndarray,         # NodeCoords
@@ -266,6 +271,11 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
     uniq_types, uniq_counts = np.unique(elem_types, return_counts=True)
     for elemType, elemCount in zip(uniq_types, uniq_counts):
         elemCounter[elemType] = elemCount
+
+    # Fill the IJK-sorting array
+    elemIJK = None
+    if hasattr(mesh_vars, 'nElemsIJK'):
+        elemIJK = np.vstack([elem.elemIJK for elem in elems]).astype(np.int32)
 
     # Set the global side ID
     globalSideID     = 0
@@ -379,7 +389,7 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
         linCache[elemType] = mapLin
 
     # Calculate the NodeInfo
-    nodeCount  = 0
+    nodeCount = 0
     for elem in elems:
         # Mesh coordinates are stored in meshIO sorting
         elemType = elem.type
@@ -400,6 +410,6 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
     else:
         FEMElemInfo = vertexInfo = vertexConnectInfo = edgeInfo = edgeConnectInfo = None
 
-    return elemInfo, sideInfo, nodeInfo, nodeCoords, \
+    return elemInfo, elemIJK, sideInfo, nodeInfo, nodeCoords, \
            FEMElemInfo, vertexInfo, vertexConnectInfo, edgeInfo, edgeConnectInfo, \
            elemCounter

--- a/pyhope/mesh/mesh_sort.py
+++ b/pyhope/mesh/mesh_sort.py
@@ -275,6 +275,13 @@ def SortMeshByIJK() -> None:
     for newElemID, oldElemID in enumerate(sorted_indices):
         elem        = elems[oldElemID]
         elem.elemID = newElemID
+
+        # Calculate IJK position for this element
+        k =  newElemID                                       // (nElemsIJK[0] * nElemsIJK[1])
+        j = (newElemID - k * nElemsIJK[0] * nElemsIJK[1])    //  nElemsIJK[0]
+        i =  newElemID - k * nElemsIJK[0] * nElemsIJK[1] - j *   nElemsIJK[0]
+        elem.elemIJK = np.array([i+1, j+1, k+1], dtype=np.int32)
+
         sorted_elems[newElemID] = elem
 
         # Correct the sideID
@@ -293,6 +300,7 @@ def SortMeshByIJK() -> None:
 
     mesh_vars.elems = sorted_elems
     mesh_vars.sides = sorted_sides
+    mesh_vars.nElemsIJK = nElemsIJK
 
     # Close the progress bar
     bar.close()

--- a/pyhope/mesh/mesh_vars.py
+++ b/pyhope/mesh/mesh_vars.py
@@ -60,6 +60,9 @@ periNodes: dict                                   # Mapping from the periodic no
 # Mesh curving
 already_curved: bool                              # Flag if mesh is already curved
 
+# Mesh sorting
+nElemsIJK: Optional[np.ndarray]                   # Number of elements in each structured dimension
+
 # Mesh connectitivity
 doMortars: bool                                   # Flag if mortars are enabled
 doPeriodicCorrect: bool                           # Flag if displacement between periodic elements should be corrected
@@ -182,6 +185,8 @@ class ELEM:
     elemID      : Optional[int]  = None
     sides       : Optional[Union[list, np.ndarray]] = None
     nodes       : Optional[            np.ndarray]  = None
+    # Sorting
+    elemIJK     : Optional[np.ndarray] = None
     # Jacobian
     jacobian    : Optional[float] = None
     # FEM connectivity


### PR DESCRIPTION
When setting `MeshSorting = IJK` / `doSortIJK = T`, HOPR generates an array giving the structured shape (`nElems_IJK`) and a mapping array (`Elem_IJK`) to query the unique IJK index of each element. These arrays were previously missing from the PyHOPE output.