### PR TITLE
Bugfix: Restrict number of threads during concurrent BLAS execution

### DIFF
--- a/pyhope/basis/basis_basis.py
+++ b/pyhope/basis/basis_basis.py
@@ -32,6 +32,7 @@ from typing import Union
 # ----------------------------------------------------------------------------------------------------------------------------------
 import numpy as np
 import scipy as sp
+from threadpoolctl import ThreadpoolController
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Local imports
 from pyhope.mesh.mesh_common import NDOFS_ELEM
@@ -307,7 +308,10 @@ def polynomial_derivative_matrix_prism(order: int, xGP: np.ndarray) -> np.ndarra
                 Vs[:, iX] *= scale
                 iX += 1
 
-    sVdm     = np.linalg.inv(Vdm)
+    # PERF: Need to use threadpoolctl here as BLAS has issues with multiprocessing
+    #       > Workaround by restricting to one thread during concurrent execution
+    with ThreadpoolController().limit(limits=1, user_api='blas'):
+        sVdm = np.linalg.inv(Vdm)
     D[1, :, :] = (Vr @ sVdm).T
     D[0, :, :] = (Vs @ sVdm).T
     D[2, :, :] = (Vt @ sVdm).T
@@ -359,9 +363,10 @@ def polynomial_derivative_matrix_pyram(order: int, xGP: np.ndarray) -> np.ndarra
                 Vs[:, iX] *= 2
                 iX += 1
 
-    # DEBUG: Need to use SciPy here as Numpy has issues with multiprocessing
-    # sVdm     = np.linalg.inv(Vdm)
-    sVdm     = sp.linalg.inv(Vdm)
+    # PERF: Need to use threadpoolctl here as BLAS has issues with multiprocessing
+    #       > Workaround by restricting to one thread during concurrent execution
+    with ThreadpoolController().limit(limits=1, user_api='blas'):
+        sVdm = np.linalg.inv(Vdm)
     D[0, :, :] = (Vr @ sVdm).T
     D[1, :, :] = (Vs @ sVdm).T
     D[2, :, :] = (Vt @ sVdm).T
@@ -420,9 +425,10 @@ def polynomial_derivative_matrix_tetra(order: int, xGP: np.ndarray) -> np.ndarra
                 Vs[:, iX] *= 2
                 iX += 1
 
-    # DEBUG: Need to use SciPy here as Numpy has issues with multiprocessing
-    # sVdm     = np.linalg.inv(Vdm)
-    sVdm     = sp.linalg.inv(Vdm)
+    # PERF: Need to use threadpoolctl here as BLAS has issues with multiprocessing
+    #       > Workaround by restricting to one thread during concurrent execution
+    with ThreadpoolController().limit(limits=1, user_api='blas'):
+        sVdm = np.linalg.inv(Vdm)
     D[0, :, :] = (Vr @ sVdm).T
     D[1, :, :] = (Vs @ sVdm).T
     D[2, :, :] = (Vt @ sVdm).T

--- a/pyhope/common/common_parallel.py
+++ b/pyhope/common/common_parallel.py
@@ -28,7 +28,7 @@
 import sys
 import traceback
 from multiprocessing import Pool, Queue, Process
-from typing import Callable
+from typing import Callable, Union
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -39,7 +39,7 @@ from alive_progress import alive_bar
 # ==================================================================================================================================
 
 
-def distribute_work(elems: tuple, chunk_size: int) -> tuple:
+def distribute_work(elems: Union[list, tuple], chunk_size: int) -> tuple:
     """Distribute elements into chunks of a given size
     """
     return tuple(elems[i:i + chunk_size] for i in range(0, len(elems), chunk_size))
@@ -59,7 +59,12 @@ def update_progress(progress_queue: Queue, total_elements: int) -> None:
             processed_count += chunk_size
 
 
-def run_in_parallel(process_chunk: Callable, elems: tuple, chunk_size: int = 10, initializer=None, init_args=()) -> list:
+def run_in_parallel(process_chunk: Callable,            # noqa: E251
+                    elems        : Union[list, tuple],  # noqa: E251
+                    chunk_size   : int   = 10,          # noqa: E251
+                    initializer          = None,        # noqa: E251
+                    init_args    : tuple = ()
+                   ) -> list:
     """Run the element processing in parallel using a specified number of processes
     """
     # Local imports ----------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     'scipy',
     'gmsh',
     # 'sortedcontainers',
-    'typing-extensions'
+    'typing-extensions',
+    'threadpoolctl'
 ]
 keywords = ["PyHOPE", "mesh generator"]
 classifiers = [


### PR DESCRIPTION
`np.linalg.inv` and `sp.linalg.inv` can run into a deadlock if running concurrent in a parallel section with a high number of threads. Work around the issue by restricting this section to sequential execution.