### PR TITLE
Library: Lift metadata, extend staticmethods

### DIFF
--- a/pyhope/__init__.py
+++ b/pyhope/__init__.py
@@ -28,6 +28,7 @@
 # ----------------------------------------------------------------------------------------------------------------------------------
 from collections import namedtuple
 from contextlib import contextmanager
+from functools import update_wrapper
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -35,25 +36,57 @@ from contextlib import contextmanager
 # Local imports
 # ----------------------------------------------------------------------------------------------------------------------------------
 from pyhope.basis.basis_basis import legendre_gauss_nodes, legendre_gauss_lobatto_nodes
-from pyhope.basis.basis_basis import barycentric_weights, polynomial_derivative_matrix
+from pyhope.basis.basis_basis import barycentric_weights
+from pyhope.basis.basis_basis import polynomial_derivative_matrix, polynomial_derivative_matrix_prism
+from pyhope.basis.basis_basis import polynomial_derivative_matrix_pyram, polynomial_derivative_matrix_tetra
 from pyhope.basis.basis_basis import lagrange_interpolation_polys, calc_vandermonde
-from pyhope.basis.basis_basis import change_basis_3D, change_basis_2D
-from pyhope.basis.basis_basis import evaluate_jacobian
+from pyhope.basis.basis_basis import change_basis_3D, change_basis_2D, change_basis_1D
+from pyhope.basis.basis_basis import equi_nodes_prism, equi_nodes_pyram, equi_nodes_tetra
+from pyhope.basis.basis_basis import evaluate_jacobian, evaluate_jacobian_simplex
+from pyhope.mesh.mesh_common import LINMAP
 # ==================================================================================================================================
 
 
-class Basis:
+def _staticwrapper(func):
+    """ Custom helper to lift the (annotations, doc, etc.) to the staticmethod
+    """
+    # Create a wrapper that carries the metadata
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    # Lift metadata (annotations, doc, etc.) to the wrapper
+    update_wrapper(wrapper, func)
+
+    # Convert the metadata-rich wrapper into a staticmethod
+    return staticmethod(wrapper)
+
+
+class Basis:  # pragma: no cover
     """ Basis class to hold all basis related functions and variables
     """
-    legendre_gauss_nodes         = staticmethod(legendre_gauss_nodes)
-    legendre_gauss_lobatto_nodes = staticmethod(legendre_gauss_lobatto_nodes)
-    barycentric_weights          = staticmethod(barycentric_weights)
-    polynomial_derivative_matrix = staticmethod(polynomial_derivative_matrix)
-    lagrange_interpolation_polys = staticmethod(lagrange_interpolation_polys)
-    calc_vandermonde             = staticmethod(calc_vandermonde)
-    change_basis_3D              = staticmethod(change_basis_3D)
-    change_basis_2D              = staticmethod(change_basis_2D)
-    evaluate_jacobian            = staticmethod(evaluate_jacobian)
+    legendre_gauss_nodes               = _staticwrapper(legendre_gauss_nodes)
+    legendre_gauss_lobatto_nodes       = _staticwrapper(legendre_gauss_lobatto_nodes)
+    barycentric_weights                = _staticwrapper(barycentric_weights)
+    polynomial_derivative_matrix       = _staticwrapper(polynomial_derivative_matrix)
+    polynomial_derivative_matrix_prism = _staticwrapper(polynomial_derivative_matrix_prism)
+    polynomial_derivative_matrix_pyram = _staticwrapper(polynomial_derivative_matrix_pyram)
+    polynomial_derivative_matrix_tetra = _staticwrapper(polynomial_derivative_matrix_tetra)
+    lagrange_interpolation_polys       = _staticwrapper(lagrange_interpolation_polys)
+    calc_vandermonde                   = _staticwrapper(calc_vandermonde)
+    change_basis_3D                    = _staticwrapper(change_basis_3D)
+    change_basis_2D                    = _staticwrapper(change_basis_2D)
+    change_basis_1D                    = _staticwrapper(change_basis_1D)
+    equi_nodes_prism                   = _staticwrapper(equi_nodes_prism)
+    equi_nodes_pyram                   = _staticwrapper(equi_nodes_pyram)
+    equi_nodes_tetra                   = _staticwrapper(equi_nodes_tetra)
+    evaluate_jacobian                  = _staticwrapper(evaluate_jacobian)
+    evaluate_jacobian_simplex          = _staticwrapper(evaluate_jacobian_simplex)
+
+
+class Mapping:  # pragma: no cover
+    """ Mapping class to hold all mapping related functions and variables
+    """
+    mesh_format_to_tensor_product      = _staticwrapper(LINMAP)
 
 
 # Define a named tuple to hold the mesh data
@@ -61,13 +94,14 @@ MeshContainer = namedtuple('Mesh',
                           ['mesh',   # The generated mesh object
                            'nGeo',   # Polynomial order
                            'bcs',    # Boundary conditions
+                           'vvs',    # Periodic vectors
                            'elems',  # Elements
                            'sides'   # Sides
                           ])
 
 
 @contextmanager  # pragma: no cover
-def Mesh(*args: str, stdout: bool = False, stderr: bool = True):
+def Mesh(*args: str, stdout: bool = False, stderr: bool = True):  # pragma: no cover
     """ Mesh context manager to generate a mesh from a given file
 
         Args:
@@ -139,10 +173,11 @@ def Mesh(*args: str, stdout: bool = False, stderr: bool = True):
                 ConnectMesh()
 
         # Export mesh variables
-        mesh = mesh_vars.mesh
+        mesh  = mesh_vars.mesh
 
         nGeo  = mesh_vars.nGeo
         bcs   = mesh_vars.bcs
+        vvs   = mesh_vars.vvs
 
         elems = mesh_vars.elems
         sides = mesh_vars.sides
@@ -150,6 +185,7 @@ def Mesh(*args: str, stdout: bool = False, stderr: bool = True):
         yield MeshContainer(mesh  = mesh,   # noqa: E251
                             nGeo  = nGeo,   # noqa: E251
                             bcs   = bcs,    # noqa: E251
+                            vvs   = vvs,    # noqa: E251
                             elems = elems,  # noqa: E251
                             sides = sides   # noqa: E251
                            )

--- a/pyhope/basis/basis_basis.py
+++ b/pyhope/basis/basis_basis.py
@@ -607,6 +607,15 @@ else:
         return x2D_Out.reshape(dim1, n_Out, n_Out)
 
 
+def change_basis_1D(Vdm: np.ndarray, x1D_In: np.ndarray) -> np.ndarray:
+    """ Interpolate a 1D tensor product Lagrange basis defined by (N_in+1) 1D interpolation point positions xi_In(0:N_In)
+        to another 1D tensor product node positions (number of nodes N_out+1)
+        defined by (N_out+1) interpolation point positions xi_Out(0:N_Out)
+        xi is defined in the 1D reference element xi=[-1,1]
+    """
+    return Vdm @ x1D_In
+
+
 def evaluate_jacobian(xGeo_In: np.ndarray, VdmGLtoAP: np.ndarray, D_EqToGL: np.ndarray) -> np.ndarray:
     """ Calculate the Jacobian of the mapping for a given element
     """

--- a/pyhope/io/formats/meshio.py
+++ b/pyhope/io/formats/meshio.py
@@ -174,7 +174,7 @@ def facePointMESHIO(start: int, end: int, face: int, pos: int) -> np.ndarray:
 
 
 @cache
-def HEXMAPMESHIO(order: int) -> Tuple[np.ndarray, np.ndarray]:
+def HEXAMAPMESHIO(order: int) -> Tuple[np.ndarray, np.ndarray]:
     """ MESHIO -> IJK ordering for high-order hexahedrons
         > HEXTEN : np.ndarray # MESHIO <-> IJK ordering for high-order hexahedrons (1D, tensor-product style)
         > HEXMAP : np.ndarray # MESHIO <-> IJK ordering for high-order hexahedrons (3D mapping)

--- a/pyhope/io/formats/vtk.py
+++ b/pyhope/io/formats/vtk.py
@@ -41,7 +41,7 @@ import numpy as np
 
 
 @cache                                                       # pragma: no cover
-def HEXMAPVTK(order: int) -> Tuple[np.ndarray, np.ndarray]:  # pragma: no cover
+def HEXAMAPVTK(order: int) -> Tuple[np.ndarray, np.ndarray]:  # pragma: no cover
     """ VTK -> IJK ordering for high-order hexahedrons
         > Loosely based on [Gmsh] "generatePointsHexCGNS"
         > [Jens Ulrich Kreber] "paraview-scripts/node_ordering. py"

--- a/pyhope/mesh/mesh_common.py
+++ b/pyhope/mesh/mesh_common.py
@@ -28,7 +28,7 @@
 from __future__ import annotations
 import sys
 from functools import cache
-from typing import Union, Tuple, Any, Final
+from typing import Any, Final, Optional, Union, Tuple
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -661,81 +661,81 @@ def calc_elem_bary(elems: list) -> np.ndarray:
 
 
 @cache
-def LINTEN(elemType: int, order: int = 1) -> tuple[np.ndarray, dict[np.int64, int]]:
+def LINTEN(elemType: int,
+           order: int = 1,
+           format: Optional[str] = 'meshio'
+           ) -> tuple[np.ndarray, dict[np.int64, int]]:
     """ MESHIO -> IJK ordering for element volume nodes
     """
     # Local imports ----------------------------------------
     # from pyhope.io.formats.cgns import genHEXMAPCGNS
-    # from pyhope.io.formats.vtk import genHEXMAPVTK
-    from pyhope.io.formats.meshio import TETRMAPMESHIO, PYRAMAPMESHIO, PRISMAPMESHIO, HEXMAPMESHIO
+    from pyhope.io.formats.vtk import HEXAMAPVTK
+    from pyhope.io.formats.meshio import TETRMAPMESHIO, PYRAMAPMESHIO, PRISMAPMESHIO, HEXAMAPMESHIO
     # ------------------------------------------------------
     # Check if we try to access a curved element with a straight-sided mapping
     if order > 1 and elemType < 200:
         raise ValueError(f'Error in LINTEN: order {order} is not supported for elemType {elemType}')
 
+    match format:
+        case 'meshio':
+            TETRMAP = TETRMAPMESHIO
+            PYRAMAP = PYRAMAPMESHIO
+            PRISMAP = PRISMAPMESHIO
+            HEXAMAP = HEXAMAPMESHIO
+        case 'vtk':
+            TETRMAP = lambda order, et=elemType: (_ for _ in ()).throw(  # noqa: E731, F841
+                         ValueError(f'TETRMAP forbidden for VTK format (elemType: {et})'))
+            PYRAMAP = lambda order, et=elemType: (_ for _ in ()).throw(  # noqa: E731, F841
+                         ValueError(f'TETRMAP forbidden for VTK format (elemType: {et})'))
+            PRISMAP = lambda order, et=elemType: (_ for _ in ()).throw(  # noqa: E731, F841
+                         ValueError(f'TETRMAP forbidden for VTK format (elemType: {et})'))
+            HEXAMAP = HEXAMAPVTK
+        case _:
+            raise ValueError(f'Unsupported mesh format: {format}')
+
     match elemType:
         # Straight-sided elements, hard-coded
         case 104:  # Tetraeder
-            # return np.array((0, 1, 2, 3))
             TETRTEN = np.array((0, 1, 2, 3))
-            # meshio accesses them in their own ordering
-            # > need to reverse the mapping
+            # meshio accesses them in their own ordering, so reverse the order
             TENTETR   = {k: v for v, k in enumerate(TETRTEN)}
             return TETRTEN, TENTETR
         case 105:  # Pyramid
-            # return np.array((0, 1, 3, 2, 4))
             PYRATEN = np.array((0, 1, 3, 2, 4))
-            # meshio accesses them in their own ordering
-            # > need to reverse the mapping
+            # meshio accesses them in their own ordering, so reverse the order
             TENPYRA   = {k: v for v, k in enumerate(PYRATEN)}
             return PYRATEN, TENPYRA
         case 106:  # Prism
-            # return np.array((0, 1, 2, 3, 4, 5))
             PRISTEN = np.array((0, 1, 2, 3, 4, 5))
-            # meshio accesses them in their own ordering
-            # > need to reverse the mapping
+            # meshio accesses them in their own ordering, so reverse the order
             TENPRIS   = {k: v for v, k in enumerate(PRISTEN)}
             return PRISTEN, TENPRIS
         case 108:  # Hexaeder
-            # return np.array((0, 1, 3, 2, 4, 5, 7, 6))
             HEXTEN = np.array((0, 1, 3, 2, 4, 5, 7, 6))
-            # meshio accesses them in their own ordering
-            # > need to reverse the mapping
+            # meshio accesses them in their own ordering, so reverse the order
             TENHEX    = {k: v for v, k in enumerate(HEXTEN)}
             return HEXTEN, TENHEX
         # Curved elements, use mapping
         case 204:  # Tetraeder
-            _, TETRTEN = TETRMAPMESHIO(order+1)
-            # meshio accesses them in their own ordering
-            # > need to reverse the mapping
+            _, TETRTEN = TETRMAP(order+1)
+            # meshio accesses them in their own ordering, so reverse the order
             TENTETR   = {k: v for v, k in enumerate(TETRTEN)}
             return TETRTEN, TENTETR
         case 205:  # Pyramid
-            _, PYRATEN = PYRAMAPMESHIO(order+1)
-            # meshio accesses them in their own ordering
-            # > need to reverse the mapping
+            _, PYRATEN = PYRAMAP(order+1)
+            # meshio accesses them in their own ordering, so reverse the order
             TENPYRA   = {k: v for v, k in enumerate(PYRATEN)}
             return PYRATEN, TENPYRA
         case 206:  # Prism
-            _, PRISTEN = PRISMAPMESHIO(order+1)
-            # meshio accesses them in their own ordering
-            # > need to reverse the mapping
+            _, PRISTEN = PRISMAP(order+1)
+            # meshio accesses them in their own ordering, so reverse the order
             TENPRIS   = {k: v for v, k in enumerate(PRISTEN)}
             return PRISTEN, TENPRIS
         case 208:  # Hexaeder
-            # > HEXTEN : np.ndarray # MESHIO <-> IJK ordering for high-order hexahedrons (1D, tensor-product style)
-            # > HEXMAP : np.ndarray # MESHIO <-> IJK ordering for high-order hexahedrons (3D mapping)
-
-            # # CGNS
-            # _, HEXTEN = HEXMAPCGNS(order+1)
-
-            # # VTK
-            # _, HEXTEN = HEXMAPVTK(order+1)
-
-            # MESHIO
-            _, HEXTEN = HEXMAPMESHIO(order+1)
-            # meshio accesses them in their own ordering
-            # > need to reverse the mapping
+            # > HEXTEN : np.ndarray # FORMAT <-> IJK ordering for high-order hexahedrons (1D, tensor-product style)
+            # > HEXMAP : np.ndarray # FORMAT <-> IJK ordering for high-order hexahedrons (3D mapping)
+            _, HEXTEN = HEXAMAP(order+1)
+            # meshio accesses them in their own ordering, so reverse the order
             TENHEX    = {k: v for v, k in enumerate(HEXTEN)}
             return HEXTEN, TENHEX
         case _:  # Default
@@ -750,7 +750,7 @@ def LINMAP(elemType: int, order: int = 1) -> npt.NDArray[np.int32]:
     # Local imports ----------------------------------------
     # from pyhope.io.formats.cgns import HEXMAPCGNS
     # from pyhope.io.formats.vtk import HEXMAPVTK
-    from pyhope.io.formats.meshio import TETRMAPMESHIO, PYRAMAPMESHIO, PRISMAPMESHIO, HEXMAPMESHIO
+    from pyhope.io.formats.meshio import TETRMAPMESHIO, PYRAMAPMESHIO, PRISMAPMESHIO, HEXAMAPMESHIO
     # ------------------------------------------------------
     # Check if we try to access a curved element with a straight-sided mapping
     if order > 1 and elemType < 200:
@@ -807,7 +807,7 @@ def LINMAP(elemType: int, order: int = 1) -> npt.NDArray[np.int32]:
             # HEXMAP  , _ = HEXMAPVTK(order+1)
 
             # MESHIO
-            HEXMAP  , _ = HEXMAPMESHIO(order+1)
+            HEXMAP  , _ = HEXAMAPMESHIO(order+1)
             return HEXMAP
         case _:  # Default
             print('Error in LINMAP, unknown elemType')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,8 @@ ignore_names = [
     "time_function",
     # Exclude monkey-patching MeshIO
     "__init__", "data_counter", "h5_file", "_meshio_to_gmsh_order",
-    # Exclude VTK ordering (used externally)
-    "HEXMAPVTK"
+    # Exclude library functions
+    "Basis", "Mapping", "Mesh",
+    "mesh_format_to_tensor_product"
     ]
 sort_by_size = true


### PR DESCRIPTION
Currently, the LRU wrapper prevents access to metadata. Lift the metadata up from the wrapper. 

Also, add these new library functions:
- Basis
  - calc_vandermonde
  - change_basis_3D
  - change_basis_2D
  - change_basis_1D
  - equi_nodes_prism
  - equi_nodes_pyram
  - equi_nodes_tetra
  - evaluate_jacobian
  - evaluate_jacobian_simplex
- Mapping:
  - mesh_format_to_tensor_product