### PR TITLE
Gambit reader: Implement different elemTypes

### DIFF
--- a/pyhope/mesh/mesh_builtin.py
+++ b/pyhope/mesh/mesh_builtin.py
@@ -80,7 +80,13 @@ def MeshCartesian() -> meshio.Mesh:
     gmsh.option.setNumber('Mesh.RandomFactor'          , 0)                       # No perturbation
     gmsh.option.setNumber('Mesh.SubdivisionAlgorithm'  , 0)                       # No subdivision/refinement
     gmsh.option.setNumber('Mesh.Algorithm'             , 3)                       # Initial mesh only
+    # gmsh.option.setNumber('Mesh.Algorithm3D'           , 10)                      # HXT algorithm
     gmsh.option.setNumber('Geometry.AutoCoherence'     , 2)                       # Remove duplicate entities
+
+    # Avoid mesh size interpolation
+    gmsh.option.setNumber('Mesh.MeshSizeFromPoints'        , 0)
+    gmsh.option.setNumber('Mesh.MeshSizeFromCurvature'     , 0)
+    gmsh.option.setNumber('Mesh.MeshSizeExtendFromBoundary', 0)
 
     # To connect the generated cells, we can simply set
     gmsh.option.setNumber('Mesh.RecombineAll'          , 1)

--- a/pyhope/mesh/reader/reader_gambit.py
+++ b/pyhope/mesh/reader/reader_gambit.py
@@ -47,14 +47,15 @@ elemTypeClass = mesh_vars.ELEMTYPE()
 
 
 @cache
-def gambit_faces(elemType: Union[int, str]) -> list[str]:
+def gambit_faces(elemType: Union[int, str]) -> tuple[str, ...]:
     """ Return a list of all sides of an element
     """
     faces_map = {  # Tetrahedron
+                   4: ('y-', 'x+', 'y+', 'z-'            ),
                    # Pyramid
                    # Wedge / Prism
                    # Hexahedron
-                   8: ['y-', 'x+', 'y+', 'x-', 'z-', 'z+']
+                   8: ('y-', 'x+', 'y+', 'x-', 'z-', 'z+'),
                 }
 
     if isinstance(elemType, str):

--- a/pyhope/mesh/reader/reader_gambit.py
+++ b/pyhope/mesh/reader/reader_gambit.py
@@ -130,6 +130,10 @@ def ReadGambit(fnames: list, mesh: meshio.Mesh) -> meshio.Mesh:
                 elemLine = lines_that_contain('ELEMENTS/CELLS', content)[0] + 1
                 elemIter = iter(content[elemLine:])
 
+                # Initialize counter for different element types
+                elemCnt  = dict.fromkeys(elemTypeClass.name.values(), 0)
+                elemMap  = [0 for _ in range(nelems)]
+
                 # Iterate and unpack the element connectivity
                 for line in elemIter:
                     if 'ENDOFSECTION' in line:
@@ -163,9 +167,15 @@ def ReadGambit(fnames: list, mesh: meshio.Mesh) -> meshio.Mesh:
 
                     cells.setdefault(elemType, []).append(elemNodes.astype(np.uint64))
 
+                    # Increment the element counter
+                    elemCnt[elemTypeClass.name[elemType]] += 1
+                    elemMap[elemID-1] = elemCnt[elemTypeClass.name[elemType]]
+
+
                 # Clean-up for memory safety
                 del elemLine
                 del elemIter
+                del elemCnt
 
                 # Check if the number of elements match the header
                 if nelems != sum(len(cells[key]) for key in cells):
@@ -267,6 +277,9 @@ def ReadGambit(fnames: list, mesh: meshio.Mesh) -> meshio.Mesh:
                                 # Map gambit element type to meshio element type
                                 elemType  = node_ordering.typing_gambit_to_meshio(gType)
 
+                                # Map the element ID to the meshio element ID
+                                elemID    = elemMap[elemID-1]
+
                                 # Get the face
                                 elem      = cells[elemType][elemID-1]
                                 face      = gambit_faces(elemType)[faceID-1]
@@ -305,6 +318,7 @@ def ReadGambit(fnames: list, mesh: meshio.Mesh) -> meshio.Mesh:
 
     # Convert points_list back to a NumPy array
     points = np.array(pointl)
+    del pointl
 
     # > CS2: We build the cell sets depending on the cells
     cell_sets:  dict[str, list] = mesh.cell_sets

--- a/pyhope/mesh/reader/reader_gambit.py
+++ b/pyhope/mesh/reader/reader_gambit.py
@@ -83,11 +83,11 @@ def ReadGambit(fnames: list, mesh: meshio.Mesh) -> meshio.Mesh:
     points   = mesh.points if len(mesh.points.shape)>1 else np.zeros((0, 3), dtype=np.float64)
     pointl   = cast(list, points.tolist())
     cells    = mesh.cells_dict
-    cellsets = defaultdict(lambda: defaultdict(list))
+    cellsets = defaultdict(lambda: defaultdict(list), mesh.cell_sets_dict)
 
-    nodeCoords   = mesh.points
-    nSides       = np.zeros(2, dtype=int)
-    elemTypes    = []
+    # Create the reader objects
+    nSides    = np.zeros(2, dtype=int)
+    elemTypes = []
 
     # Initialize the node ordering
     node_ordering = NodeOrdering()
@@ -170,7 +170,6 @@ def ReadGambit(fnames: list, mesh: meshio.Mesh) -> meshio.Mesh:
                     # Increment the element counter
                     elemCnt[elemTypeClass.name[elemType]] += 1
                     elemMap[elemID-1] = elemCnt[elemTypeClass.name[elemType]]
-
 
                 # Clean-up for memory safety
                 del elemLine

--- a/pyhope/mesh/reader/reader_hopr.py
+++ b/pyhope/mesh/reader/reader_hopr.py
@@ -64,14 +64,14 @@ def ReadHOPR(fnames: list, mesh: meshio.Mesh) -> meshio.Mesh:
 
     hopout.sep()
 
-    # Create an empty meshio object
+    # Create or re-use the meshio object
     points   = mesh.points if len(mesh.points.shape)>1 else np.zeros((0, 3), dtype=np.float64)
     pointl   = cast(list, points.tolist())
     cells    = mesh.cells_dict
-    cellsets = defaultdict(lambda: defaultdict(list))
+    cellsets = defaultdict(lambda: defaultdict(list), mesh.cell_sets_dict)
 
-    nodeCoords   = mesh.points
-    offsetnNodes = nodeCoords.shape[0]
+    # Create the reader objects
+    offsetnNodes = mesh.points.shape[0]
     nSides       = np.zeros(2, dtype=int)
 
     # Vandermonde for changeBasis

--- a/pyhope/meshio/meshio_convert.py
+++ b/pyhope/meshio/meshio_convert.py
@@ -52,7 +52,7 @@ if typing.TYPE_CHECKING:
 
 def gmsh_to_meshio(gmsh: ModuleType) -> meshio.Mesh:
     """
-    Convert a Gmsh object to a meshio object.
+    Convert a Gmsh object to a meshio object
     """
     # Local imports ----------------------------------------
     from pyhope.meshio.meshio_ordering import NodeOrdering

--- a/pyhope/meshio/meshio_ordering.py
+++ b/pyhope/meshio/meshio_ordering.py
@@ -249,7 +249,7 @@ class NodeOrdering:
     # Dictionary for translation of  gambit types to gmsh codes
     _gambit_typing: dict[int, str] = field(
             default_factory=lambda: { 1  : 'line'          , 2  : 'quad'          , 3  : 'triangle'      , 4  : 'hexahedron'    ,
-                                      5  : 'wedge'         , 6  : 'tetrahedron'   , 7  : 'pyramid'                              ,
+                                      5  : 'wedge'         , 6  : 'tetra'         , 7  : 'pyramid'                              ,
                                     }
     )
 
@@ -260,7 +260,7 @@ class NodeOrdering:
                                        # 2D elements
                                        # 3D elements
                                        # > Hexahedron
-                                       'hexahedron':   [0, 1, 3, 2, 4, 5, 7, 6],
+                                       'hexahedron':   [ 0, 1, 3, 2, 4, 5, 7, 6],
                                     }
     )
 

--- a/pyhope/meshio/meshio_ordering.py
+++ b/pyhope/meshio/meshio_ordering.py
@@ -221,7 +221,7 @@ class NodeOrdering:
                                        'tetra10'     : [ 0, 1, 2, 3, 4, 5, 6, 7, 9, 8 ],
                                        'tetra20'     : [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 10, 15, 14, 13, 12, 17, 19, 18, 16 ],
                                        'tetra35'     : [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 14, 13, 21, 20, 19, 18, 17, 16,  # noqa: E501
-                                                         25, 26, 27, 32, 33, 31, 28, 30, 29, 22, 24, 23, 34],
+                                                         25, 26, 27, 32, 33, 31, 28, 30, 29, 22, 24, 23, 34 ],
                                        # > Wedge
                                        'wedge'       : [ 0, 1, 2, 3, 4, 5],
                                        'wedge15'     : [ 0, 1, 2, 3, 4, 5, 6, 9, 7, 12, 14, 13, 8, 10, 11 ],
@@ -259,8 +259,12 @@ class NodeOrdering:
                                        # 1D elements
                                        # 2D elements
                                        # 3D elements
+                                       # > Tetrahedron
+                                       'tetra'     : [ 0, 1, 2, 3 ],
+                                       # > Pyramid
+                                       # > Wedge / Prism
                                        # > Hexahedron
-                                       'hexahedron':   [ 0, 1, 3, 2, 4, 5, 7, 6],
+                                       'hexahedron': [ 0, 1, 3, 2, 4, 5, 7, 6 ],
                                     }
     )
 
@@ -403,8 +407,7 @@ class NodeOrdering:
     #     return mapping
 
     def typing_gambit_to_meshio(self, elemType: Union[int, str, np.uint]) -> str:
-        """
-        Return the meshIO element type for a given Gambit element type
+        """ Return the meshIO element type for a given Gambit element type
         """
         if isinstance(elemType, (int, np.integer)):
             return self._gambit_typing[int(elemType)]
@@ -412,8 +415,7 @@ class NodeOrdering:
         raise ValueError(f'Unknown element type {elemType}')
 
     def ordering_gambit_to_meshio(self, elemType: Union[int, str, np.uint], idx: npt.NDArray) -> npt.NDArray:
-        """
-        Return the meshIO node ordering for a given element type
+        """ Return the meshIO node ordering for a given element type
         """
         if isinstance(elemType, (int, np.integer)):
             elemType = self._gambit_typing[int(elemType)]


### PR DESCRIPTION
Previously, the Gambit reader assumed hexahedrons. Add (theoretical) support for different element types. Also, actually merge different cell sets when supplying multiple mesh formats.