### PR TITLE
Bugfix: Fix all failing pre-commit checks

### DIFF
--- a/.github/scripts/convergence.py
+++ b/.github/scripts/convergence.py
@@ -30,12 +30,12 @@ convfile = "convergence.log"
 
 
 # Set tolerance bounds: (N+1)+-0.35
-def compute_expected_range(N):
+def compute_expected_range(N: int) -> tuple[float, float]:
     return N + 0.65, N + 1.35
 
 
 # Process the results
-def process_results(degree, data):
+def process_results(degree: int, data: list) -> bool:
     min_eoc, max_eoc = compute_expected_range(degree)
     print(f"\n=== Checking EOCs for Polynomial Degree N={degree} (Expected: [{min_eoc}, {max_eoc}]) ===")
     results = []
@@ -47,7 +47,7 @@ def process_results(degree, data):
 
 
 # Draw the results as a table
-def draw_table(results):
+def draw_table(results: list) -> None:
     print("\n┌───────┬─────────┬─────────┬─────────┬────────┐")
     print("│ Mesh  │   min   │   max   │  result │ Passed │")
     print("├───────┼─────────┼─────────┼─────────┼────────┤")

--- a/.gmsh/build_macos.py
+++ b/.gmsh/build_macos.py
@@ -28,8 +28,10 @@
 import os
 import sys
 import build  # ty: ignore [unresolved-import]
+import contextlib
 # import errno
 import multiprocessing
+import pathlib
 import platform
 import re
 import shutil
@@ -37,6 +39,7 @@ import subprocess
 import tarfile
 import urllib.request
 import xml.etree.ElementTree as ET
+from collections.abc import Callable
 from typing import Optional, Final
 # ==================================================================================================================================
 
@@ -48,17 +51,17 @@ def print_header(title: str) -> None:
     """ Prints a nicely formatted header with a title
     """
     header_line = '=' * 80
-    print('\n{}\n{:^80}\n{}'.format(header_line, title, header_line))
+    print(f'\n{header_line}\n{title:^80}\n{header_line}')
 
 
 def print_step(step_description: str) -> None:
     """ Prints a step description in a consistent format
     """
-    print('➤ {}'.format(step_description))
+    print(f'➤ {step_description}')
 
 
 # Helper function for version checks
-def get_latest_version(fetch_fn, name: str, fallback: str) -> str:
+def get_latest_version(fetch_fn: Callable, name: str, fallback: str) -> str:
     """ Updates a vresion string
     """
     try:
@@ -74,15 +77,15 @@ def get_latest_version(fetch_fn, name: str, fallback: str) -> str:
 # Helper function for downloads
 def download(url: str, dir: str) -> str:
     file = os.path.join(dir, os.path.basename(url))
-    print_step('Downloading: {} to {}'.format(url, file))
+    print_step(f'Downloading: {url} to {file}')
     urllib.request.urlretrieve(url, file)
     return file
 
 
 # Helper function to extract .tar.gz files
 def extract(file: str, dir: str) -> None:
-    print_step('Extracting: {} to {}'.format(file, dir))
-    if file.endswith('.tar.gz') or file.endswith('.tgz'):
+    print_step(f'Extracting: {file} to {dir}')
+    if file.endswith(('.tar.gz', '.tgz')):
         mode = 'r:gz'
     elif file.endswith('.tar.xz'):
         mode = 'r:xz'
@@ -90,7 +93,7 @@ def extract(file: str, dir: str) -> None:
     #     subprocess.call(['unzip', '-j', file])
     #     return None
     else:
-        raise ValueError('Unsupported archive format: {}'.format(file))
+        raise ValueError(f'Unsupported archive format: {file}')
 
     with tarfile.open(file, mode) as tar:
         tar.extractall(path=dir)
@@ -102,18 +105,8 @@ def configure(configure_cmd: list, cwd: Optional[str] = None, env: Optional[dict
 
     # Run the configure script ...
     configure_path = os.path.join(cwd, 'configure')
-    if os.path.isfile(configure_path):
-        print_step('Configuring with: {}'.format(configure_cmd))
-        subprocess.run(configure_cmd, check=True, cwd=cwd, env=env, stderr=sys.stderr, stdout=sys.stdout)
-
-    # ... or the cmake script
-    elif configure_cmd[0] == 'cmake':
-        print_step('Configuring with: {}'.format(configure_cmd))
-        subprocess.run(configure_cmd, check=True, cwd=cwd, env=env, stderr=sys.stderr, stdout=sys.stdout)
-
-    # ... or the meson script
-    elif configure_cmd[0] == 'meson':
-        print_step('Configuring with: {}'.format(configure_cmd))
+    if os.path.isfile(configure_path) or configure_cmd[0] == 'cmake' or configure_cmd[0] == 'meson':
+        print_step(f'Configuring with: {configure_cmd}')
         subprocess.run(configure_cmd, check=True, cwd=cwd, env=env, stderr=sys.stderr, stdout=sys.stdout)
 
     else:
@@ -123,7 +116,7 @@ def configure(configure_cmd: list, cwd: Optional[str] = None, env: Optional[dict
 
 def compile(install_cmd: Optional[list] = None, ncores: int = 1, cwd: Optional[str] = None, env: Optional[dict] = None) -> None:
     # Build the software
-    print_step('Building with {} cores'.format(ncores))
+    print_step(f'Building with {ncores} cores')
     subprocess.run(['make', f'-j{ncores}'], check=True, cwd=cwd, env=env, stderr=sys.stderr, stdout=sys.stdout)
 
     # Run the install command if provided
@@ -272,7 +265,7 @@ def _scrape_latest(url: str, pattern: str) -> str:
     if not versions:
         raise ValueError(f'No versions found at {url}')
 
-    return sorted(versions, key=lambda v: list(map(int, v.split('.'))))[-1]
+    return max(versions, key=lambda v: list(map(int, v.split('.'))))
 
 
 def _github_latest_tag(owner: str, repo: str, prefix: str = '', tag_filter: Optional[str] = None) -> str:
@@ -316,7 +309,7 @@ GMSH_STRING           = 'gmsh_{}'.format(GMSH_VERSION.replace('.', '_'))
 # ------------------------------------------------------------------------
 # Clean any previous build artifacts
 # ------------------------------------------------------------------------
-def clean():
+def clean() -> None:
     print_header('CLEANING UP PREVIOUS BUILD ARTIFACTS...')
 
     shutil.rmtree(BUILD_DIR,         ignore_errors=True)
@@ -342,10 +335,8 @@ def clean():
     shutil.rmtree(DIST_DIR,          ignore_errors=True)
     shutil.rmtree(EGG_DIR,           ignore_errors=True)
     # Python wheel
-    try:
+    with contextlib.suppress(OSError):
         os.remove(os.path.join(WORK_DIR, 'dist', f'gmsh-{GMSH_FULLVER}-py3-none-any.whl'))
-    except OSError:
-        pass
 
     os.makedirs(BUILD_DIR,   exist_ok=True)
     os.makedirs(INSTALL_DIR, exist_ok=True)
@@ -364,7 +355,7 @@ def build_zlib() -> None:
     zlib_src_dir = os.path.join(BUILD_DIR, f'zlib-{ZLIB_VERSION}')
     conf_cmd = [ 'cmake',
                  '-G', 'Unix Makefiles',
-                 '-DCMAKE_INSTALL_PREFIX={}'.format(ZLIB_DIR),
+                 f'-DCMAKE_INSTALL_PREFIX={ZLIB_DIR}',
                  '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
                  '-DBUILD_SHARED_LIBS=OFF',
                  '-DZLIB_BUILD_EXAMPLES=OFF',
@@ -441,7 +432,7 @@ def build_hdf5() -> None:
 
     hdf5_src_dir = os.path.join(BUILD_DIR, f'hdf5-{HDF5_VERSION}')
     conf_cmd = [ './configure',
-                '--prefix={}'.format(HDF5_DIR),
+                f'--prefix={HDF5_DIR}',
                 '--enable-static',
                 # '--enable-shared'
                 '--disable-shared',
@@ -450,7 +441,7 @@ def build_hdf5() -> None:
                 '--disable-hl',
                 '--disable-tools',
                 '--disable-tests',
-                '--with-zlib={}'.format(ZLIB_DIR),
+                f'--with-zlib={ZLIB_DIR}',
                 ]
     conf_env = os.environ.copy()
     conf_env['CFLAGS'  ] = '-O2 -fPIC'
@@ -484,7 +475,7 @@ def build_tcl() -> None:
 
     tcl_src_dir = os.path.join(BUILD_DIR, f'tcl{TCL_VERSION}', 'unix')
     conf_cmd = ['./configure',
-                '--prefix={}'.format(TCL_DIR),
+                f'--prefix={TCL_DIR}',
                 # '--enable-static',
                 '--disable-shared',
                 '--enable-64bit',
@@ -517,8 +508,8 @@ def build_tk() -> None:
 
     tk_src_dir = os.path.join(BUILD_DIR, f'tk{TK_VERSION}', 'unix')
     conf_cmd = ['./configure',
-                '--prefix={}'.format(TK_DIR),
-                '--with-tcl={}/lib'.format(TCL_DIR),
+                f'--prefix={TK_DIR}',
+                f'--with-tcl={TCL_DIR}/lib',
                 # '--enable-static',
                 '--disable-shared',
                 '--enable-64bit',
@@ -544,7 +535,7 @@ def build_tk() -> None:
 # ------------------------------------------------------------------------
 # Build FreeTyoe
 # ------------------------------------------------------------------------
-def build_freetype():
+def build_freetype() -> None:
     print_header('BUILDING FREETYPE2')
 
     freetype_src_dir = os.path.join(BUILD_DIR, f'freetype-{FREETYPE_VERSION}')
@@ -555,7 +546,7 @@ def build_freetype():
     extract(file, BUILD_DIR)
 
     conf_cmd  = ['./configure',
-                 '--prefix={}'.format(FREETYPE_DIR),
+                 f'--prefix={FREETYPE_DIR}',
                  '--enable-static',
                  '--disable-shared',
                  # '--enable-shared',
@@ -576,13 +567,13 @@ def build_freetype():
     configure(conf_cmd,              env=conf_env, cwd=freetype_src_dir)
     compile( build_cmd, build_cores, env=conf_env, cwd=freetype_src_dir)
 
-    print_step('FreeType2 installed at: {}'.format(FREETYPE_DIR))
+    print_step(f'FreeType2 installed at: {FREETYPE_DIR}')
 
 
 # ------------------------------------------------------------------------
 # Build libPNG
 # ------------------------------------------------------------------------
-def build_libpng():
+def build_libpng() -> None:
     print_header('BUILDING LIBPNG')
 
     libpng_src_dir = os.path.join(BUILD_DIR, f'libpng-{LIBPNG_VERSION}')
@@ -594,11 +585,11 @@ def build_libpng():
     extract(file, BUILD_DIR)
 
     conf_cmd  = ['./configure',
-                 '--prefix={}'.format(LIBPNG_DIR),
-                 #'--disable-static',
+                 f'--prefix={LIBPNG_DIR}',
+                 # '--disable-static',
                  '--enable-static',
                  '--disable-shared',
-                 #'--enable-shared',
+                 # '--enable-shared',
                  ]
     conf_env = os.environ.copy()
     conf_env['CFLAGS']          = '-O2 -fPIC'
@@ -613,13 +604,13 @@ def build_libpng():
     configure(conf_cmd,              env=conf_env, cwd=libpng_src_dir)
     compile( build_cmd, build_cores, env=conf_env, cwd=libpng_src_dir)
 
-    print_step('libPNG installed at: {}'.format(LIBPNG_DIR))
+    print_step(f'libPNG installed at: {LIBPNG_DIR}')
 
 
 # ------------------------------------------------------------------------
 # Build libPNG
 # ------------------------------------------------------------------------
-def build_libjpeg():
+def build_libjpeg() -> None:
     print_header('BUILDING LIBJPEG(-TURBO)')
 
     libjpeg_src_dir = os.path.join(BUILD_DIR, f'libjpeg-turbo-{LIBJPEG_TURBO_VERSION}')
@@ -644,7 +635,7 @@ def build_libjpeg():
                  # '-DENABLE_STATIC=OFF',
                  # '-DENABLE_SHARED=ON',
                  '-DWITH_JPEG8=ON',
-                 '-DCMAKE_INSTALL_PREFIX={}'.format(LIBJPEG_TURBO_DIR),
+                 f'-DCMAKE_INSTALL_PREFIX={LIBJPEG_TURBO_DIR}',
                  '-DCMAKE_POSITION_INDEPENDENT_CODE=1',
                  '-DENABLE_EXECUTABLES=OFF',
                  '-DWITH_TURBOJPEG=OFF',
@@ -664,13 +655,13 @@ def build_libjpeg():
     configure(conf_cmd,              env=conf_env, cwd=libjpeg_src_dir)
     compile( build_cmd, build_cores, env=conf_env, cwd=libjpeg_src_dir)
 
-    print_step('libJPEG(-turbo) installed at: {}'.format(LIBJPEG_TURBO_DIR))
+    print_step(f'libJPEG(-turbo) installed at: {LIBJPEG_TURBO_DIR}')
 
 
 # ------------------------------------------------------------------------
 # Build libxft
 # ------------------------------------------------------------------------
-def build_libxft():
+def build_libxft() -> None:
     print_header('BUILDING LIBXFT...')
 
     libxft_src_dir = os.path.join(BUILD_DIR, f'libXft-{LIBXFT_VERSION}')
@@ -685,11 +676,11 @@ def build_libxft():
     # Configure and build libxft with freetype dependency
     conf_cmd = [
         './configure',
-        '--prefix={}'.format(LIBXFT_DIR),
+        f'--prefix={LIBXFT_DIR}',
         '--disable-static',
         '--enable-shared',
         # '--enable-static',
-        '--with-freetype-config={}/bin/freetype-config'.format(FREETYPE_DIR),  # Link freetype
+        f'--with-freetype-config={FREETYPE_DIR}/bin/freetype-config',  # Link freetype
         '--with-fontconfig'  # Fontconfig is commonly used with Xft for font handling
     ]
     conf_env  = os.environ.copy()
@@ -709,7 +700,7 @@ def build_libxft():
 # ------------------------------------------------------------------------
 # Build Fontconfig (Static)
 # ------------------------------------------------------------------------
-def build_fontconfig():
+def build_fontconfig() -> None:
     print_header('Building Fontconfig...')
     # fontconfig_url = f'https://www.freedesktop.org/software/fontconfig/release/fontconfig-{FONTCONFIG_VERSION}.tar.gz'
     fontconfig_url = f'https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/{FONTCONFIG_VERSION}/fontconfig-{FONTCONFIG_VERSION}.tar.xz'
@@ -749,7 +740,7 @@ def build_fontconfig():
 # ------------------------------------------------------------------------
 # Build FLTK
 # ------------------------------------------------------------------------
-def build_fltk():
+def build_fltk() -> None:
     print_header('BUILDING FLTK')
 
     fltk_src_dir = os.path.join(BUILD_DIR, f'fltk-{FLTK_VERSION}')
@@ -768,7 +759,7 @@ def build_fltk():
 
     conf_cmd = [
         './configure',
-        '--prefix={}'.format(FLTK_DIR),
+        f'--prefix={FLTK_DIR}',
         # '--includedir={}'.format(os.path.join(BUILD_DIR, 'include')),
         # '--enable-static',
         '--disable-shared',
@@ -810,7 +801,7 @@ def build_fltk():
                                                       conf_env['LD_LIBRARY_PATH'])
 
     conf_env['FREETYPE_LIBS'  ] = os.path.join(FREETYPE_DIR, 'lib')
-    conf_env['LIBPNG_PATH'    ] = '{}'.format(LIBPNG_DIR)
+    conf_env['LIBPNG_PATH'    ] = f'{LIBPNG_DIR}'
     conf_env['PKG_CONFIG_PATH'] = '{}{}{}'.format(os.path.join(FREETYPE_DIR,      'lib',   'pkgconfig'), os.pathsep,
                                                   os.path.join(FONTCONFIG_DIR,    'lib',   'pkgconfig'))
     conf_env['PKG_CONFIG_PATH'] = '{}{}{}'.format(os.path.join(LIBPNG_DIR,        'lib',   'pkgconfig'), os.pathsep,
@@ -830,13 +821,13 @@ def build_fltk():
     configure(conf_cmd,              env=conf_env, cwd=fltk_src_dir)
     compile( build_cmd, build_cores, env=conf_env, cwd=fltk_src_dir)
 
-    print_step('FLTK installed at: {}'.format(FLTK_DIR))
+    print_step(f'FLTK installed at: {FLTK_DIR}')
 
 
 # ------------------------------------------------------------------------
 # Ensure gperf is installed
 # ------------------------------------------------------------------------
-def build_gperf():
+def build_gperf() -> None:
     print_header('Building gperf...')
     gperf_url = f"https://ftp.gnu.org/pub/gnu/gperf/gperf-{GPERF_VERSION}.tar.gz"
 
@@ -886,17 +877,17 @@ def build_cgns() -> None:
     if 'PATH' in conf_env:
         conf_env['PATH']  = '{}{}{}'.format(os.path.join(HDF5_DIR), os.pathsep, conf_env['PATH'])
     else:
-        conf_env['PATH']  = '{}'.format(   os.path.join(HDF5_DIR))
-    conf_env['HDF5_DIR']  = '{}'.format(   os.path.join(HDF5_DIR))
-    conf_env['HDF5_ROOT'] = '{}'.format(   os.path.join(HDF5_DIR))
+        conf_env['PATH']  = f'{os.path.join(HDF5_DIR)}'
+    conf_env['HDF5_DIR']  = f'{os.path.join(HDF5_DIR)}'
+    conf_env['HDF5_ROOT'] = f'{os.path.join(HDF5_DIR)}'
     conf_cmd = [
         'cmake', cgns_dir,
-        '-DCMAKE_INSTALL_PREFIX={}/install'.format(CGNS_DIR),
+        f'-DCMAKE_INSTALL_PREFIX={CGNS_DIR}/install',
         '-DCMAKE_BUILD_TYPE=Release',
-        '-DHDF5_DIR={}'.format(HDF5_DIR),
-        '-DHDF5_ROOT={}'.format(HDF5_DIR),
-        '-DHDF5_INCLUDE_DIR={}/include'.format(HDF5_DIR),
-        '-DHDF5_LIBRARY={}/lib/libhdf5.a'.format(HDF5_DIR),
+        f'-DHDF5_DIR={HDF5_DIR}',
+        f'-DHDF5_ROOT={HDF5_DIR}',
+        f'-DHDF5_INCLUDE_DIR={HDF5_DIR}/include',
+        f'-DHDF5_LIBRARY={HDF5_DIR}/lib/libhdf5.a',
         '-DCGNS_ENABLE_HDF5=ON',
         '-DCGNS_BUILD_SHARED=OFF',
         '-DCGNS_ENABLE_FORTRAN=OFF',
@@ -964,7 +955,7 @@ def build_occt() -> None:
     conf_cmd = [
         'cmake', occ_dir,
         '-DCMAKE_BUILD_TYPE=Release',
-        '-DCMAKE_INSTALL_PREFIX={}/install'.format(OCC_DIR),
+        f'-DCMAKE_INSTALL_PREFIX={OCC_DIR}/install',
         '-DBUILD_LIBRARY_TYPE=Static',
         '-DBUILD_MODULE_ApplicationFramework=OFF',
         '-DBUILD_MODULE_DataExchange=ON',           # needed by Gmsh for STEP/IGES
@@ -1060,21 +1051,19 @@ def build_gmsh() -> None:
                                                      conf_env['CMAKE_INCLUDE_PATH'])
 
     # Now, patch the file paths
-    with open(os.path.join(WORK_DIR, 'gmsh', 'CMakeLists.txt'), 'r') as file:
-        filedata = file.read()
+    filedata = pathlib.Path(os.path.join(WORK_DIR, 'gmsh', 'CMakeLists.txt')).read_text()
 
     # Replace the target string
     filedata = filedata.replace('--use-gl --use-images --ldflags', '--use-gl --use-images --ldstaticflags')
 
     # Write the file out again
-    with open(os.path.join(WORK_DIR, 'gmsh', 'CMakeLists.txt'), 'w') as file:
-        file.write(filedata)
+    pathlib.Path(os.path.join(WORK_DIR, 'gmsh', 'CMakeLists.txt')).write_text(filedata)
 
     conf_env['PATH']      = '{}{}{}'.format(os.path.join(HDF5_DIR, 'bin'), os.pathsep, conf_env['PATH'])
     conf_env['PATH']      = '{}{}{}'.format(os.path.join(FLTK_DIR, 'bin'), os.pathsep, conf_env['PATH'])
     conf_env['PATH']      = '{}{}{}'.format(os.path.join(HDF5_DIR)       , os.pathsep, conf_env['PATH'])
-    conf_env['FLTK_DIR']  = '{}'.format(    os.path.join(FLTK_DIR))
-    conf_env['HDF5_DIR']  = '{}'.format(    os.path.join(HDF5_DIR))
+    conf_env['FLTK_DIR']  = f'{os.path.join(FLTK_DIR)}'
+    conf_env['HDF5_DIR']  = f'{os.path.join(HDF5_DIR)}'
     # conf_env['HDF5_ROOT'    ] = os.path.join(HDF5_DIR)
     # conf_env['FREETYPE_LIBS'] = os.path.join(FREETYPE_DIR, 'lib')
     conf_env['CASROOT']   = os.path.join(OCC_DIR , 'install')
@@ -1082,16 +1071,16 @@ def build_gmsh() -> None:
     conf_cmd = [
         'cmake', '..',
         '-DCMAKE_BUILD_TYPE=Release',
-        '-DCMAKE_INSTALL_PREFIX={}'.format(INSTALL_DIR),
-        '-DFREETYPE_LIBRARY={}/lib/libfreetype.a'.format(FREETYPE_DIR),
-        '-DFREETYPE_INCLUDE_DIRS={}/include'.format(FREETYPE_DIR),
-        '-DHDF5_INCLUDE_DIRS={}/include'.format(HDF5_DIR),
-        '-DJPEG_LIBRARY={}/lib64/libjpeg.a'.format(LIBJPEG_TURBO_DIR),
-        '-DJPEG_INCLUDE_DIR={}/include'.format(LIBJPEG_TURBO_DIR),
+        f'-DCMAKE_INSTALL_PREFIX={INSTALL_DIR}',
+        f'-DFREETYPE_LIBRARY={FREETYPE_DIR}/lib/libfreetype.a',
+        f'-DFREETYPE_INCLUDE_DIRS={FREETYPE_DIR}/include',
+        f'-DHDF5_INCLUDE_DIRS={HDF5_DIR}/include',
+        f'-DJPEG_LIBRARY={LIBJPEG_TURBO_DIR}/lib64/libjpeg.a',
+        f'-DJPEG_INCLUDE_DIR={LIBJPEG_TURBO_DIR}/include',
         # '-DPNG_LIBRARY={}/lib/libpng.so'.format(LIBPNG_DIR),
-        '-DPNG_LIBRARY={}/lib/libpng.a'.format(LIBPNG_DIR),
-        '-DPNG_INCLUDE_DIR={}/include'.format(LIBPNG_DIR),
-        '-DPNG_PNG_INCLUDE_DIR={}/include'.format(LIBPNG_DIR),
+        f'-DPNG_LIBRARY={LIBPNG_DIR}/lib/libpng.a',
+        f'-DPNG_INCLUDE_DIR={LIBPNG_DIR}/include',
+        f'-DPNG_PNG_INCLUDE_DIR={LIBPNG_DIR}/include',
         '-DENABLE_BUILD_LIB=ON',
         '-DENABLE_BUILD_SHARED=ON',
         '-DENABLE_MPEG_ENCODE=OFF',
@@ -1144,17 +1133,17 @@ def package() -> None:
     # Copy the CGNS adf2hdf executable
     CGNS_ADF2HDF = os.path.join(WORK_DIR   , 'CGNS', 'install', 'bin', 'adf2hdf')
     CGNS_ADF_DIR = os.path.join(INSTALL_DIR, 'bin' , 'adf2hdf')
-    print_step('Copying adf2hdf from {} to {}'.format(CGNS_ADF2HDF, CGNS_ADF_DIR))
+    print_step(f'Copying adf2hdf from {CGNS_ADF2HDF} to {CGNS_ADF_DIR}')
     shutil.copy(CGNS_ADF2HDF, CGNS_ADF_DIR)
 
     # Copy the CGNS cgnsconvert executable
     CGNS_CGNSCON = os.path.join(WORK_DIR   , 'CGNS', 'install', 'bin', 'cgnsconvert')
     CGNS_CGN_DIR = os.path.join(INSTALL_DIR, 'bin' , 'cgnsconvert')
-    print_step('Copying cgnsconvert from {} to {}'.format(CGNS_CGNSCON, CGNS_CGN_DIR))
+    print_step(f'Copying cgnsconvert from {CGNS_CGNSCON} to {CGNS_CGN_DIR}')
     shutil.copy(CGNS_CGNSCON, CGNS_CGN_DIR)
 
     # Copy the Gmsh Python API file
-    print_step('Copying gmsh.py from {} to {}'.format(GMESH_PY_API, GMESH_PY_DST))
+    print_step(f'Copying gmsh.py from {GMESH_PY_API} to {GMESH_PY_DST}')
     shutil.copy(GMESH_PY_API, GMESH_PY_DST)
 
     # Run setup to build the Python wheel
@@ -1220,14 +1209,13 @@ def package() -> None:
     """
 
     # Open the file in write mode and write the content
-    with open(os.path.join(WORK_DIR, 'pyproject.toml'), 'w') as file:
-        file.write(pyproject)
+    pathlib.Path(os.path.join(WORK_DIR, 'pyproject.toml')).write_text(pyproject)
 
     builder = build.ProjectBuilder(WORK_DIR)
     builder.build('wheel', os.path.join(WORK_DIR, 'dist'))
 
     # Rename the generated Python wheel
-    print_step('Renaming the wheel to {}'.format(PYTHON_WHEEL))
+    print_step(f'Renaming the wheel to {PYTHON_WHEEL}')
     shutil.move(os.path.join(WORK_DIR, 'dist', f'gmsh-{GMSH_FULLVER}-py3-none-any.whl'), os.path.join(WORK_DIR, PYTHON_WHEEL))
 
     print_header('PYTHON WHEEL BUILD COMPLETED!')

--- a/.gmsh/build_manylinux.py
+++ b/.gmsh/build_manylinux.py
@@ -28,8 +28,10 @@
 import os
 import sys
 import build  # ty: ignore [unresolved-import]
+import contextlib
 # import errno
 import multiprocessing
+import pathlib
 import platform
 import re
 import shutil
@@ -37,6 +39,7 @@ import subprocess
 import tarfile
 import urllib.request
 import xml.etree.ElementTree as ET
+from collections.abc import Callable
 from typing import Optional, Final
 # ==================================================================================================================================
 
@@ -48,17 +51,17 @@ def print_header(title: str) -> None:
     """ Prints a nicely formatted header with a title
     """
     header_line = '=' * 80
-    print('\n{}\n{:^80}\n{}'.format(header_line, title, header_line))
+    print(f'\n{header_line}\n{title:^80}\n{header_line}')
 
 
 def print_step(step_description: str) -> None:
     """ Prints a step description in a consistent format
     """
-    print('➤ {}'.format(step_description))
+    print(f'➤ {step_description}')
 
 
 # Helper function for version checks
-def get_latest_version(fetch_fn, name: str, fallback: str) -> str:
+def get_latest_version(fetch_fn: Callable, name: str, fallback: str) -> str:
     """ Updates a vresion string
     """
     try:
@@ -74,15 +77,15 @@ def get_latest_version(fetch_fn, name: str, fallback: str) -> str:
 # Helper function for downloads
 def download(url: str, dir: str) -> str:
     file = os.path.join(dir, os.path.basename(url))
-    print_step('Downloading: {} to {}'.format(url, file))
+    print_step(f'Downloading: {url} to {file}')
     urllib.request.urlretrieve(url, file)
     return file
 
 
 # Helper function to extract .tar.gz files
 def extract(file: str, dir: str) -> None:
-    print_step('Extracting: {} to {}'.format(file, dir))
-    if file.endswith('.tar.gz') or file.endswith('.tgz'):
+    print_step(f'Extracting: {file} to {dir}')
+    if file.endswith(('.tar.gz', '.tgz')):
         mode = 'r:gz'
     elif file.endswith('.tar.xz'):
         mode = 'r:xz'
@@ -90,7 +93,7 @@ def extract(file: str, dir: str) -> None:
     #     subprocess.call(['unzip', '-j', file])
     #     return None
     else:
-        raise ValueError('Unsupported archive format: {}'.format(file))
+        raise ValueError(f'Unsupported archive format: {file}')
 
     with tarfile.open(file, mode) as tar:
         tar.extractall(path=dir)
@@ -102,18 +105,8 @@ def configure(configure_cmd: list, cwd: Optional[str] = None, env: Optional[dict
 
     # Run the configure script ...
     configure_path = os.path.join(cwd, 'configure')
-    if os.path.isfile(configure_path):
-        print_step('Configuring with: {}'.format(configure_cmd))
-        subprocess.run(configure_cmd, check=True, cwd=cwd, env=env, stderr=sys.stderr, stdout=sys.stdout)
-
-    # ... or the cmake script
-    elif configure_cmd[0] == 'cmake':
-        print_step('Configuring with: {}'.format(configure_cmd))
-        subprocess.run(configure_cmd, check=True, cwd=cwd, env=env, stderr=sys.stderr, stdout=sys.stdout)
-
-    # ... or the meson script
-    elif configure_cmd[0] == 'meson':
-        print_step('Configuring with: {}'.format(configure_cmd))
+    if os.path.isfile(configure_path) or configure_cmd[0] == 'cmake' or configure_cmd[0] == 'meson':
+        print_step(f'Configuring with: {configure_cmd}')
         subprocess.run(configure_cmd, check=True, cwd=cwd, env=env, stderr=sys.stderr, stdout=sys.stdout)
 
     else:
@@ -123,7 +116,7 @@ def configure(configure_cmd: list, cwd: Optional[str] = None, env: Optional[dict
 
 def compile(install_cmd: Optional[list] = None, ncores: int = 1, cwd: Optional[str] = None, env: Optional[dict] = None) -> None:
     # Build the software
-    print_step('Building with {} cores'.format(ncores))
+    print_step(f'Building with {ncores} cores')
     subprocess.run(['make', f'-j{ncores}'], check=True, cwd=cwd, env=env, stderr=sys.stderr, stdout=sys.stdout)
 
     # Run the install command if provided
@@ -274,7 +267,7 @@ def _scrape_latest(url: str, pattern: str) -> str:
     if not versions:
         raise ValueError(f'No versions found at {url}')
 
-    return sorted(versions, key=lambda v: list(map(int, v.split('.'))))[-1]
+    return max(versions, key=lambda v: list(map(int, v.split('.'))))
 
 
 def _github_latest_tag(owner: str, repo: str, prefix: str = '', tag_filter: Optional[str] = None) -> str:
@@ -318,7 +311,7 @@ GMSH_STRING           = 'gmsh_{}'.format(GMSH_VERSION.replace('.', '_'))
 # ------------------------------------------------------------------------
 # Clean any previous build artifacts
 # ------------------------------------------------------------------------
-def clean():
+def clean() -> None:
     print_header('CLEANING UP PREVIOUS BUILD ARTIFACTS...')
 
     shutil.rmtree(BUILD_DIR,         ignore_errors=True)
@@ -344,10 +337,8 @@ def clean():
     shutil.rmtree(DIST_DIR,          ignore_errors=True)
     shutil.rmtree(EGG_DIR,           ignore_errors=True)
     # Python wheel
-    try:
+    with contextlib.suppress(OSError):
         os.remove(os.path.join(WORK_DIR, 'dist', f'gmsh-{GMSH_FULLVER}-py3-none-any.whl'))
-    except OSError:
-        pass
 
     os.makedirs(BUILD_DIR,   exist_ok=True)
     os.makedirs(INSTALL_DIR, exist_ok=True)
@@ -366,7 +357,7 @@ def build_zlib() -> None:
     zlib_src_dir = os.path.join(BUILD_DIR, f'zlib-{ZLIB_VERSION}')
     conf_cmd = [ 'cmake',
                  '-G', 'Unix Makefiles',
-                 '-DCMAKE_INSTALL_PREFIX={}'.format(ZLIB_DIR),
+                 f'-DCMAKE_INSTALL_PREFIX={ZLIB_DIR}',
                  '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
                  '-DBUILD_SHARED_LIBS=OFF',
                  '-DZLIB_BUILD_EXAMPLES=OFF',
@@ -443,7 +434,7 @@ def build_hdf5() -> None:
 
     hdf5_src_dir = os.path.join(BUILD_DIR, f'hdf5-{HDF5_VERSION}')
     conf_cmd = [ './configure',
-                '--prefix={}'.format(HDF5_DIR),
+                f'--prefix={HDF5_DIR}',
                 '--enable-static',
                 # '--enable-shared'
                 '--disable-shared',
@@ -452,7 +443,7 @@ def build_hdf5() -> None:
                 '--disable-hl',
                 '--disable-tools',
                 '--disable-tests',
-                '--with-zlib={}'.format(ZLIB_DIR),
+                f'--with-zlib={ZLIB_DIR}',
                 ]
     conf_env = os.environ.copy()
     conf_env['CFLAGS'  ] = '-O2 -fPIC'
@@ -486,7 +477,7 @@ def build_tcl() -> None:
 
     tcl_src_dir = os.path.join(BUILD_DIR, f'tcl{TCL_VERSION}', 'unix')
     conf_cmd = ['./configure',
-                '--prefix={}'.format(TCL_DIR),
+                f'--prefix={TCL_DIR}',
                 # '--enable-static',
                 '--disable-shared',
                 '--enable-64bit',
@@ -519,8 +510,8 @@ def build_tk() -> None:
 
     tk_src_dir = os.path.join(BUILD_DIR, f'tk{TK_VERSION}', 'unix')
     conf_cmd = ['./configure',
-                '--prefix={}'.format(TK_DIR),
-                '--with-tcl={}/lib'.format(TCL_DIR),
+                f'--prefix={TK_DIR}',
+                f'--with-tcl={TCL_DIR}/lib',
                 # '--enable-static',
                 '--disable-shared',
                 '--enable-64bit',
@@ -546,7 +537,7 @@ def build_tk() -> None:
 # ------------------------------------------------------------------------
 # Build FreeTyoe
 # ------------------------------------------------------------------------
-def build_freetype():
+def build_freetype() -> None:
     print_header('BUILDING FREETYPE2')
 
     freetype_src_dir = os.path.join(BUILD_DIR, f'freetype-{FREETYPE_VERSION}')
@@ -557,7 +548,7 @@ def build_freetype():
     extract(file, BUILD_DIR)
 
     conf_cmd  = ['./configure',
-                 '--prefix={}'.format(FREETYPE_DIR),
+                 f'--prefix={FREETYPE_DIR}',
                  '--enable-static',
                  '--disable-shared',
                  # '--enable-shared',
@@ -578,13 +569,13 @@ def build_freetype():
     configure(conf_cmd,              env=conf_env, cwd=freetype_src_dir)
     compile( build_cmd, build_cores, env=conf_env, cwd=freetype_src_dir)
 
-    print_step('FreeType2 installed at: {}'.format(FREETYPE_DIR))
+    print_step(f'FreeType2 installed at: {FREETYPE_DIR}')
 
 
 # ------------------------------------------------------------------------
 # Build libPNG
 # ------------------------------------------------------------------------
-def build_libpng():
+def build_libpng() -> None:
     print_header('BUILDING LIBPNG')
 
     libpng_src_dir = os.path.join(BUILD_DIR, f'libpng-{LIBPNG_VERSION}')
@@ -596,7 +587,7 @@ def build_libpng():
     extract(file, BUILD_DIR)
 
     conf_cmd  = ['./configure',
-                 '--prefix={}'.format(LIBPNG_DIR),
+                 f'--prefix={LIBPNG_DIR}',
                  # '--disable-static',
                  '--enable-static',
                  '--disable-shared',
@@ -615,13 +606,13 @@ def build_libpng():
     configure(conf_cmd,              env=conf_env, cwd=libpng_src_dir)
     compile( build_cmd, build_cores, env=conf_env, cwd=libpng_src_dir)
 
-    print_step('libPNG installed at: {}'.format(LIBPNG_DIR))
+    print_step(f'libPNG installed at: {LIBPNG_DIR}')
 
 
 # ------------------------------------------------------------------------
 # Build libPNG
 # ------------------------------------------------------------------------
-def build_libjpeg():
+def build_libjpeg() -> None:
     print_header('BUILDING LIBJPEG(-TURBO)')
 
     libjpeg_src_dir = os.path.join(BUILD_DIR, f'libjpeg-turbo-{LIBJPEG_TURBO_VERSION}')
@@ -646,7 +637,7 @@ def build_libjpeg():
                  # '-DENABLE_STATIC=OFF',
                  # '-DENABLE_SHARED=ON',
                  '-DWITH_JPEG8=ON',
-                 '-DCMAKE_INSTALL_PREFIX={}'.format(LIBJPEG_TURBO_DIR),
+                 f'-DCMAKE_INSTALL_PREFIX={LIBJPEG_TURBO_DIR}',
                  '-DCMAKE_POSITION_INDEPENDENT_CODE=1',
                  '-DENABLE_EXECUTABLES=OFF',
                  '-DWITH_TURBOJPEG=OFF',
@@ -666,13 +657,13 @@ def build_libjpeg():
     configure(conf_cmd,              env=conf_env, cwd=libjpeg_src_dir)
     compile( build_cmd, build_cores, env=conf_env, cwd=libjpeg_src_dir)
 
-    print_step('libJPEG(-turbo) installed at: {}'.format(LIBJPEG_TURBO_DIR))
+    print_step(f'libJPEG(-turbo) installed at: {LIBJPEG_TURBO_DIR}')
 
 
 # ------------------------------------------------------------------------
 # Build libxft
 # ------------------------------------------------------------------------
-def build_libxft():
+def build_libxft() -> None:
     print_header('BUILDING LIBXFT...')
 
     libxft_src_dir = os.path.join(BUILD_DIR, f'libXft-{LIBXFT_VERSION}')
@@ -687,11 +678,11 @@ def build_libxft():
     # Configure and build libxft with freetype dependency
     conf_cmd = [
         './configure',
-        '--prefix={}'.format(LIBXFT_DIR),
+        f'--prefix={LIBXFT_DIR}',
         '--disable-static',
         '--enable-shared',
         # '--enable-static',
-        '--with-freetype-config={}/bin/freetype-config'.format(FREETYPE_DIR),  # Link freetype
+        f'--with-freetype-config={FREETYPE_DIR}/bin/freetype-config',  # Link freetype
         '--with-fontconfig'  # Fontconfig is commonly used with Xft for font handling
     ]
     conf_env  = os.environ.copy()
@@ -711,7 +702,7 @@ def build_libxft():
 # ------------------------------------------------------------------------
 # Build Fontconfig (Static)
 # ------------------------------------------------------------------------
-def build_fontconfig():
+def build_fontconfig() -> None:
     print_header('Building Fontconfig...')
     # fontconfig_url = f'https://www.freedesktop.org/software/fontconfig/release/fontconfig-{FONTCONFIG_VERSION}.tar.gz'
     fontconfig_url = f'https://gitlab.freedesktop.org/api/v4/projects/890/packages/generic/fontconfig/{FONTCONFIG_VERSION}/fontconfig-{FONTCONFIG_VERSION}.tar.xz'
@@ -751,7 +742,7 @@ def build_fontconfig():
 # ------------------------------------------------------------------------
 # Build FLTK
 # ------------------------------------------------------------------------
-def build_fltk():
+def build_fltk() -> None:
     print_header('BUILDING FLTK')
 
     # Add system libjpeg-turbo-devel to PATH
@@ -796,7 +787,7 @@ def build_fltk():
 
     conf_cmd = [
         './configure',
-        '--prefix={}'.format(FLTK_DIR),
+        f'--prefix={FLTK_DIR}',
         # '--includedir={}'.format(os.path.join(BUILD_DIR, 'include')),
         # '--enable-static',
         '--disable-shared',
@@ -850,7 +841,7 @@ def build_fltk():
                                                       conf_env['LD_LIBRARY_PATH'])
 
     conf_env['FREETYPE_LIBS'  ] = os.path.join(FREETYPE_DIR, 'lib')
-    conf_env['LIBPNG_PATH'    ] = '{}'.format(LIBPNG_DIR)
+    conf_env['LIBPNG_PATH'    ] = f'{LIBPNG_DIR}'
     conf_env['PKG_CONFIG_PATH'] = '{}{}{}'.format(os.path.join(FREETYPE_DIR,      'lib',   'pkgconfig'), os.pathsep,
                                                   os.path.join(FONTCONFIG_DIR,    'lib',   'pkgconfig'))
     conf_env['PKG_CONFIG_PATH'] = '{}{}{}'.format(os.path.join(LIBPNG_DIR,        'lib',   'pkgconfig'), os.pathsep,
@@ -870,13 +861,13 @@ def build_fltk():
     configure(conf_cmd,              env=conf_env, cwd=fltk_src_dir)
     compile( build_cmd, build_cores, env=conf_env, cwd=fltk_src_dir)
 
-    print_step('FLTK installed at: {}'.format(FLTK_DIR))
+    print_step(f'FLTK installed at: {FLTK_DIR}')
 
 
 # ------------------------------------------------------------------------
 # Ensure gperf is installed
 # ------------------------------------------------------------------------
-def build_gperf():
+def build_gperf() -> None:
     print_header('Building gperf...')
     gperf_url = f"https://ftp.gnu.org/pub/gnu/gperf/gperf-{GPERF_VERSION}.tar.gz"
 
@@ -926,17 +917,17 @@ def build_cgns() -> None:
     if 'PATH' in conf_env:
         conf_env['PATH']  = '{}{}{}'.format(os.path.join(HDF5_DIR), os.pathsep, conf_env['PATH'])
     else:
-        conf_env['PATH']  = '{}'.format(   os.path.join(HDF5_DIR))
-    conf_env['HDF5_DIR']  = '{}'.format(   os.path.join(HDF5_DIR))
-    conf_env['HDF5_ROOT'] = '{}'.format(   os.path.join(HDF5_DIR))
+        conf_env['PATH']  = f'{os.path.join(HDF5_DIR)}'
+    conf_env['HDF5_DIR']  = f'{os.path.join(HDF5_DIR)}'
+    conf_env['HDF5_ROOT'] = f'{os.path.join(HDF5_DIR)}'
     conf_cmd = [
         'cmake', cgns_dir,
-        '-DCMAKE_INSTALL_PREFIX={}/install'.format(CGNS_DIR),
+        f'-DCMAKE_INSTALL_PREFIX={CGNS_DIR}/install',
         '-DCMAKE_BUILD_TYPE=Release',
-        '-DHDF5_DIR={}'.format(HDF5_DIR),
-        '-DHDF5_ROOT={}'.format(HDF5_DIR),
-        '-DHDF5_INCLUDE_DIR={}/include'.format(HDF5_DIR),
-        '-DHDF5_LIBRARY={}/lib/libhdf5.a'.format(HDF5_DIR),
+        f'-DHDF5_DIR={HDF5_DIR}',
+        f'-DHDF5_ROOT={HDF5_DIR}',
+        f'-DHDF5_INCLUDE_DIR={HDF5_DIR}/include',
+        f'-DHDF5_LIBRARY={HDF5_DIR}/lib/libhdf5.a',
         '-DCGNS_ENABLE_HDF5=ON',
         '-DCGNS_BUILD_SHARED=OFF',
         '-DCGNS_ENABLE_FORTRAN=OFF',
@@ -1004,7 +995,7 @@ def build_occt() -> None:
     conf_cmd = [
         'cmake', occ_dir,
         '-DCMAKE_BUILD_TYPE=Release',
-        '-DCMAKE_INSTALL_PREFIX={}/install'.format(OCC_DIR),
+        f'-DCMAKE_INSTALL_PREFIX={OCC_DIR}/install',
         '-DBUILD_LIBRARY_TYPE=Static',
         '-DBUILD_MODULE_ApplicationFramework=OFF',
         '-DBUILD_MODULE_DataExchange=ON',           # needed by Gmsh for STEP/IGES
@@ -1120,7 +1111,7 @@ def build_gmsh() -> None:
                    shell=True)
     extract(os.path.join(BUILD_DIR, f'{lib}.tar.gz'), BUILD_DIR)
     os.environ['PKG_CONFIG_PATH'   ] = '{}'.format( os.path.join(BUILD_DIR, 'lib64', 'pkgconfig'))
-    os.environ['CMAKE_PREFIX_PATH' ] = '{}'.format( os.path.join(BUILD_DIR))
+    os.environ['CMAKE_PREFIX_PATH' ] = f'{os.path.join(BUILD_DIR)}'
     os.environ['CMAKE_LIBRARY_PATH'] = '{}'.format( os.path.join(BUILD_DIR, 'lib64'  ))
     os.environ['CMAKE_INCLUDE_PATH'] = '{}'.format( os.path.join(BUILD_DIR, 'include'))
     os.environ['GLU_INCLUDE_DIR'   ] = '{}'.format( os.path.join(BUILD_DIR, 'include'))
@@ -1143,15 +1134,13 @@ def build_gmsh() -> None:
     shutil.copytree(os.path.join(BUILD_DIR, lib, 'usr', 'include/'), os.path.join(WORK_DIR, 'build', 'include') , dirs_exist_ok=True, symlinks=True)  # noqa: E501
 
     # Now, patch the file paths
-    with open(os.path.join(BUILD_DIR, 'lib64', 'pkgconfig', 'glu.pc'), 'r') as file:
-        filedata = file.read()
+    filedata = pathlib.Path(os.path.join(BUILD_DIR, 'lib64', 'pkgconfig', 'glu.pc')).read_text()
 
     # Replace the target string
     filedata = filedata.replace('/usr', os.path.join(WORK_DIR, 'build'))
 
     # Write the file out again
-    with open(os.path.join(BUILD_DIR, 'lib64', 'pkgconfig', 'glu.pc'), 'w') as file:
-        file.write(filedata)
+    pathlib.Path(os.path.join(BUILD_DIR, 'lib64', 'pkgconfig', 'glu.pc')).write_text(filedata)
 
     gmsh_dir = os.path.join(WORK_DIR, 'gmsh')
     if os.path.exists(gmsh_dir):
@@ -1203,21 +1192,19 @@ def build_gmsh() -> None:
                                                      conf_env['CMAKE_INCLUDE_PATH'])
 
     # Now, patch the file paths
-    with open(os.path.join(WORK_DIR, 'gmsh', 'CMakeLists.txt'), 'r') as file:
-        filedata = file.read()
+    filedata = pathlib.Path(os.path.join(WORK_DIR, 'gmsh', 'CMakeLists.txt')).read_text()
 
     # Replace the target string
     filedata = filedata.replace('--use-gl --use-images --ldflags', '--use-gl --use-images --ldstaticflags')
 
     # Write the file out again
-    with open(os.path.join(WORK_DIR, 'gmsh', 'CMakeLists.txt'), 'w') as file:
-        file.write(filedata)
+    pathlib.Path(os.path.join(WORK_DIR, 'gmsh', 'CMakeLists.txt')).write_text(filedata)
 
     conf_env['PATH']      = '{}{}{}'.format(os.path.join(HDF5_DIR, 'bin'), os.pathsep, conf_env['PATH'])
     conf_env['PATH']      = '{}{}{}'.format(os.path.join(FLTK_DIR, 'bin'), os.pathsep, conf_env['PATH'])
     conf_env['PATH']      = '{}{}{}'.format(os.path.join(HDF5_DIR)       , os.pathsep, conf_env['PATH'])
-    conf_env['FLTK_DIR']  = '{}'.format(    os.path.join(FLTK_DIR))
-    conf_env['HDF5_DIR']  = '{}'.format(    os.path.join(HDF5_DIR))
+    conf_env['FLTK_DIR']  = f'{os.path.join(FLTK_DIR)}'
+    conf_env['HDF5_DIR']  = f'{os.path.join(HDF5_DIR)}'
     # conf_env['HDF5_ROOT'    ] = os.path.join(HDF5_DIR)
     # conf_env['FREETYPE_LIBS'] = os.path.join(FREETYPE_DIR, 'lib')
     conf_env['CASROOT']   = os.path.join(OCC_DIR , 'install')
@@ -1225,16 +1212,16 @@ def build_gmsh() -> None:
     conf_cmd = [
         'cmake', '..',
         '-DCMAKE_BUILD_TYPE=Release',
-        '-DCMAKE_INSTALL_PREFIX={}'.format(INSTALL_DIR),
-        '-DFREETYPE_LIBRARY={}/lib/libfreetype.a'.format(FREETYPE_DIR),
-        '-DFREETYPE_INCLUDE_DIRS={}/include'.format(FREETYPE_DIR),
-        '-DHDF5_INCLUDE_DIRS={}/include'.format(HDF5_DIR),
-        '-DJPEG_LIBRARY={}/lib64/libjpeg.a'.format(LIBJPEG_TURBO_DIR),
-        '-DJPEG_INCLUDE_DIR={}/include'.format(LIBJPEG_TURBO_DIR),
+        f'-DCMAKE_INSTALL_PREFIX={INSTALL_DIR}',
+        f'-DFREETYPE_LIBRARY={FREETYPE_DIR}/lib/libfreetype.a',
+        f'-DFREETYPE_INCLUDE_DIRS={FREETYPE_DIR}/include',
+        f'-DHDF5_INCLUDE_DIRS={HDF5_DIR}/include',
+        f'-DJPEG_LIBRARY={LIBJPEG_TURBO_DIR}/lib64/libjpeg.a',
+        f'-DJPEG_INCLUDE_DIR={LIBJPEG_TURBO_DIR}/include',
         # '-DPNG_LIBRARY={}/lib/libpng.so'.format(LIBPNG_DIR),
-        '-DPNG_LIBRARY={}/lib/libpng.a'.format(LIBPNG_DIR),
-        '-DPNG_INCLUDE_DIR={}/include'.format(LIBPNG_DIR),
-        '-DPNG_PNG_INCLUDE_DIR={}/include'.format(LIBPNG_DIR),
+        f'-DPNG_LIBRARY={LIBPNG_DIR}/lib/libpng.a',
+        f'-DPNG_INCLUDE_DIR={LIBPNG_DIR}/include',
+        f'-DPNG_PNG_INCLUDE_DIR={LIBPNG_DIR}/include',
         '-DENABLE_BUILD_LIB=ON',
         '-DENABLE_BUILD_SHARED=ON',
         '-DENABLE_MPEG_ENCODE=OFF',
@@ -1294,13 +1281,13 @@ def package() -> None:
     # Copy the CGNS adf2hdf executable
     CGNS_ADF2HDF = os.path.join(WORK_DIR   , 'CGNS', 'install', 'bin', 'adf2hdf')
     CGNS_ADF_DIR = os.path.join(INSTALL_DIR, 'bin' , 'adf2hdf')
-    print_step('Copying adf2hdf from {} to {}'.format(CGNS_ADF2HDF, CGNS_ADF_DIR))
+    print_step(f'Copying adf2hdf from {CGNS_ADF2HDF} to {CGNS_ADF_DIR}')
     shutil.copy(CGNS_ADF2HDF, CGNS_ADF_DIR)
 
     # Copy the CGNS cgnsconvert executable
     CGNS_CGNSCON = os.path.join(WORK_DIR   , 'CGNS', 'install', 'bin', 'cgnsconvert')
     CGNS_CGN_DIR = os.path.join(INSTALL_DIR, 'bin' , 'cgnsconvert')
-    print_step('Copying cgnsconvert from {} to {}'.format(CGNS_CGNSCON, CGNS_CGN_DIR))
+    print_step(f'Copying cgnsconvert from {CGNS_CGNSCON} to {CGNS_CGN_DIR}')
     shutil.copy(CGNS_CGNSCON, CGNS_CGN_DIR)
 
     # Copy the Gmsh files to the Python directory
@@ -1334,7 +1321,7 @@ def package() -> None:
     # shutil.copy(LIBJPG_LIB, LIBJPG_DST, follow_symlinks=False)
 
     # Copy the Gmsh Python API file
-    print_step('Copying gmsh.py from {} to {}'.format(GMESH_PY_API, GMESH_PY_DST))
+    print_step(f'Copying gmsh.py from {GMESH_PY_API} to {GMESH_PY_DST}')
     shutil.copy(GMESH_PY_API, GMESH_PY_DST)
 
     # Run setup to build the Python wheel
@@ -1409,8 +1396,7 @@ def package() -> None:
     """
 
     # Open the file in write mode and write the content
-    with open(os.path.join(WORK_DIR, 'pyproject.toml'), 'w') as file:
-        file.write(pyproject)
+    pathlib.Path(os.path.join(WORK_DIR, 'pyproject.toml')).write_text(pyproject)
 
     builder = build.ProjectBuilder(WORK_DIR)
     builder.build('wheel', os.path.join(WORK_DIR, 'dist'))
@@ -1421,13 +1407,13 @@ def package() -> None:
     #                cwd   = WORK_DIR)  # noqa: E251
 
     # Rename the generated Python wheel
-    print_step('Renaming the wheel to {}'.format(PYTHON_WHEEL))
+    print_step(f'Renaming the wheel to {PYTHON_WHEEL}')
     shutil.move(os.path.join(WORK_DIR, 'dist', f'gmsh-{GMSH_FULLVER}-py3-none-any.whl'), os.path.join(WORK_DIR, PYTHON_WHEEL))
 
     print_header('PYTHON WHEEL BUILD COMPLETED!')
 
-    result = subprocess.run(['sha256sum', os.path.join(WORK_DIR, PYTHON_WHEEL)], stdout=subprocess.PIPE, universal_newlines=True)
-    print_step('Wheel : {}'.format(os.path.join(WORK_DIR, PYTHON_WHEEL)))
+    result = subprocess.run(['sha256sum', os.path.join(WORK_DIR, PYTHON_WHEEL)], stdout=subprocess.PIPE, text=True, check=True)
+    print_step(f'Wheel : {os.path.join(WORK_DIR, PYTHON_WHEEL)}')
     print_step('SHA256: {}'.format(result.stdout.split(' ')[0]))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,12 @@ unused-ignore-comment      = 'ignore'
 
 # Dead code
 [tool.vulture]
+paths = [
+    "pyhope",
+    "tools",
+    ".github",
+    ".gmsh"
+]
 ignore_names = [
     # Exclude context manager
     "Basis",

--- a/tools/create_coverage.py
+++ b/tools/create_coverage.py
@@ -30,10 +30,11 @@ import os
 import shutil
 import subprocess
 import sys
+from collections.abc import Mapping
+from typing import Optional
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
 import argparse
-from typing import List, Optional, Mapping, Tuple
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Local imports
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -52,7 +53,7 @@ RESET = '\033[0m'
 def printHeader(title: str, width: int) -> None:
     ''' Print a box header for a section.
     '''
-    print('')
+    print()
     print('┌─' + '─' * width + '─┐')
     print('│ ' + f'{title:<{width}}' + ' │')
     print('└─' + '─' * width + '─┘')
@@ -60,29 +61,28 @@ def printHeader(title: str, width: int) -> None:
 
 def findCoverageFiles(base_dir   : str,
                       pattern    : str,
-                      output_name: str) -> List[str]:
+                      output_name: str) -> list[str]:
     ''' Find coverage data files in base_dir that match pattern, excluding the combined output
     '''
     candidates    = sorted(f for f in glob.glob(os.path.join(base_dir, pattern)) if os.path.isfile(f))
     combined_path = os.path.join(base_dir, output_name)
     combined_abs  = os.path.abspath(combined_path)
-    input_datafiles = [f for f in candidates if os.path.abspath(f) != combined_abs]
-    return input_datafiles
+    return [f for f in candidates if os.path.abspath(f) != combined_abs]
 
 
 def findParameterFiles(base_dir  : str,
-                       param_name: str) -> List[str]:
+                       param_name: str) -> list[str]:
     ''' Recursively find all parameter.ini files under tutorials_root
     '''
-    matches: List[str] = []
-    for base_dir, _dirs, files in os.walk(base_dir):
+    matches: list[str] = []
+    for dir, _dirs, files in os.walk(base_dir):
         if param_name in files:
-            matches.append(os.path.join(base_dir, param_name))
+            matches.append(os.path.join(dir, param_name))
     matches.sort()
     return matches
 
 
-def runCmd(cmd: List[str],
+def runCmd(cmd: list[str],
            cwd: str,
            env: Optional[Mapping[str, str]] = None) -> None:
     ''' Run a command, streaming output to the console. Raise on failure.
@@ -96,7 +96,7 @@ def runCmd(cmd: List[str],
 
 def runExamples(base_dir  : str,
                 exam_dir  : str,
-                param_name: str) -> Tuple[List[Tuple[str, str]], int]:
+                param_name: str) -> tuple[list[tuple[str, str]], int]:
     ''' Run all examples found under tutorials_root with coverage collection
     '''
     paramfiles = findParameterFiles(exam_dir, param_name)
@@ -106,14 +106,13 @@ def runExamples(base_dir  : str,
     max_dir_length = 0
     paramdirs      = [os.path.dirname(p) for p in paramfiles]
     for d in paramdirs:
-        if len(d) > max_dir_length:
-            max_dir_length = len(d)
+        max_dir_length = max(max_dir_length, len(d))
     box_width = max_dir_length + 10  # Add padding for aesthetics
     col_width = max_dir_length + 2   # Add padding for the table
 
     print('Running PyHOPE with coverage for each parameter.ini file...')
 
-    results: List[Tuple[str, str]] = []
+    results: list[tuple[str, str]] = []
     failures                        = 0
 
     for paramfile in paramfiles:
@@ -131,7 +130,7 @@ def runExamples(base_dir  : str,
             f'--source={base_dir}',
             '-m', 'pyhope', paramini,
         ]
-        proc = subprocess.run(cmd, cwd=paramdir)
+        proc = subprocess.run(cmd, cwd=paramdir, check=True)
         if proc.returncode == 0:
             results.append((paramdir, 'PASS'))
             print(f'{GREEN}✔ PASS{RESET}: {paramini}')
@@ -142,7 +141,7 @@ def runExamples(base_dir  : str,
 
     # Output the final sorted report as a UTF-8 box-drawing table
     if results:
-        print('')
+        print()
         print('┌─' + '─' * max_dir_length + '─┬────────┐')
         print('│ ' + f'{"Example Directory":<{col_width-2}}' + ' │ ' + f'{"Result":<5}' + ' │')
         print('├─' + '─' * max_dir_length + '─┼────────┤')
@@ -163,7 +162,7 @@ def runVerify(base_dir: str) -> int:
     print('Running internal health check with coverage...')
     data_file = os.path.join(base_dir, '.coverage.verify')
     cmd       = ['coverage', 'run', f'--data-file={data_file}', '-m', 'pyhope', '--verify']
-    proc      = subprocess.run(cmd, cwd=base_dir)
+    proc      = subprocess.run(cmd, cwd=base_dir, check=True)
     if proc.returncode == 0:
         print(f'{GREEN}✔ PASS{RESET}: pyhope --verify')
     else:
@@ -234,7 +233,7 @@ def main() -> int:
         if args.strict:
             print(f'{RED}{msg}{RESET}')
             # Preserve failures precedence if any occurred earlier
-            return 1 if any_failures == 0 else 1
+            return 1
         print(msg)
         # Still return failures if generation failed
         if any_failures or verify_rc != 0:

--- a/tools/create_h5stats.py
+++ b/tools/create_h5stats.py
@@ -32,6 +32,7 @@ import argparse
 import h5py
 import numpy as np
 import toml  # ty: ignore [unresolved-import]
+from typing import Union
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Local imports
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -41,11 +42,11 @@ import toml  # ty: ignore [unresolved-import]
 # ==================================================================================================================================
 
 
-def collectStats(file_path):
+def collectStats(file_path: str) -> dict:
     stats = {}
     with h5py.File(file_path, 'r') as f:
 
-        def visit_func(name, obj):
+        def visit_func(name: str, obj: Union[np.ndarray, h5py.Dataset]) -> None:
             if name not in ('ElemInfo', 'GlobalNodeIDs', 'NodeCoords', 'SideInfo'):
                 return
 
@@ -72,7 +73,7 @@ def collectStats(file_path):
     return stats
 
 
-def writeTOML(stats, output_file='analyze.toml'):
+def writeTOML(stats: dict, output_file: str = 'analyze.toml') -> None:
     # TOML tables can't have slashes, so replace with dot or underscore
     toml_compatible_stats = {name.replace('/', '.') : values for name, values in stats.items()}
     with open(output_file, 'w') as f:
@@ -80,7 +81,7 @@ def writeTOML(stats, output_file='analyze.toml'):
     print(f'Stats written to {output_file}')
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description='Collect statistics for HDF5 HOPR mesh file and output to TOML')
     parser.add_argument('file_path',      type    = str,                      # noqa: E251
                                           help    = 'Path to the HDF5 file')  # noqa: E251

--- a/tools/create_stubs.py
+++ b/tools/create_stubs.py
@@ -31,10 +31,12 @@ import re
 import subprocess
 import sys
 from collections import deque
+from collections.abc import Iterable
 from dataclasses import dataclass
 from shutil import which
 from time import time
 from typing import Final, Optional
+import pathlib
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -86,28 +88,25 @@ def find_git_root() -> str:
         result = subprocess.run(['git', 'rev-parse', '--show-toplevel'],
                                 capture_output=True, text=True, check=True)
         return result.stdout.strip()
-    except subprocess.CalledProcessError:
-        raise FileNotFoundError('Not a Git repository or unable to determine Git root.')
+    except subprocess.CalledProcessError as e:
+        raise FileNotFoundError('Not a Git repository or unable to determine Git root.') from e
 
 
 def parse_dependencies(toml_file: str) -> list:
     """ Parse the pyproject.toml file to obtain the dependencies
     """
-    with open(toml_file, 'r') as f:
-        content = f.read()
+    content = pathlib.Path(toml_file).read_text()
 
     dependencies_match = re.search(r'dependencies\s*=\s*\[([^\]]+)\]', content, re.DOTALL)
     if not dependencies_match:
         return []
 
     raw_dependencies = dependencies_match.group(1).strip()
-    dependencies = [
+    return [
         re.split(r'[<=>~]', dep.strip().strip("'\""))[0]
         for dep in raw_dependencies.split(',')
         if dep.strip()
     ]
-
-    return dependencies
 
 
 def fetch_import_name(package: str) -> Optional[str]:
@@ -135,14 +134,14 @@ def fetch_import_name(package: str) -> Optional[str]:
         try:
             _ = importlib.import_module(name_variant)
             return name_variant
-        except ImportError:
+        except ImportError:  # noqa: PERF203
             continue
 
     print(f'Warning: Unable to determine import name for {package_name}.', file=sys.stderr)
     return None
 
 
-def fetch_transitive_dependencies(package):
+def fetch_transitive_dependencies(package: str) -> list:
     """ Attempt to fetch transitive dependencies of the direct dependencies
     """
     try:
@@ -161,7 +160,7 @@ def fetch_transitive_dependencies(package):
         return []
 
 
-def collect_all_dependencies(initial_dependencies):
+def collect_all_dependencies(initial_dependencies: Iterable) -> set:
     """ Gather all collected dependencies
     """
     visited          = set()
@@ -182,7 +181,7 @@ def collect_all_dependencies(initial_dependencies):
     return all_dependencies
 
 
-def run_pyright_on_dependencies(pyright_path, dependencies):
+def run_pyright_on_dependencies(pyright_path: str, dependencies: Iterable) -> None:
     """ Run (based)pyright to generate the stubs
     """
     for dep in dependencies:


### PR DESCRIPTION
While PyHOPE itself was fine, our bundled tools caused some pre-commit checks to fail. Fix all issues, so `pre-commit run --all-files` passes cleanly.