### PR TITLE
Postdeform: Abort if transformation is illegally combined with meshScale

### DIFF
--- a/pyhope/mesh/transform/templates/cylinder.py
+++ b/pyhope/mesh/transform/templates/cylinder.py
@@ -50,11 +50,16 @@ def PostDeform(points: npt.NDArray) -> npt.NDArray:  # pragma: no cover
     """ This function applies a deformation transformation to the input points
         > The transformation maps a 2D square region to a cylindrical or toroidal coordinate system
     """
-
     # Local imports ----------------------------------------
-    from pyhope.readintools.readintools import CreateReal, GetReal
-    # from pyhope.readintools.readintools import CreateInt, GetInt
+    import pyhope.output.output as hopout
+    import pyhope.config.config as config
+    from pyhope.readintools.readintools import CreateReal, GetReal, CountOption
     # ------------------------------------------------------
+
+    # Handle the case that the variable was already used
+    config.prms['meshScale']['counter'] = max(config.prms['meshScale']['counter'] - 1, 0)
+    if CountOption('meshScale') and GetReal('meshScale') != 1.:
+        hopout.error('"meshScale" cannot be combined with template "cylinder"')
 
     # Readin parameters
     CreateReal( 'PostDeform_R0',      default= 1.0, multiple=False, help='Cylinder radius')                      # noqa: E251

--- a/pyhope/mesh/transform/templates/sphere.py
+++ b/pyhope/mesh/transform/templates/sphere.py
@@ -52,8 +52,15 @@ def PostDeform(points: npt.NDArray) -> npt.NDArray:  # pragma: no cover
           sphere
     """
     # Local imports ----------------------------------------
-    from pyhope.readintools.readintools import CreateReal, GetReal
+    import pyhope.output.output as hopout
+    import pyhope.config.config as config
+    from pyhope.readintools.readintools import CreateReal, GetReal, CountOption
     # ------------------------------------------------------
+
+    # Handle the case that the variable was already used
+    config.prms['meshScale']['counter'] = max(config.prms['meshScale']['counter'] - 1, 0)
+    if CountOption('meshScale') and GetReal('meshScale') != 1.:
+        hopout.error('"meshScale" cannot be combined with template "cylinder"')
 
     # Readin parameters
     CreateReal('PostDeform_R0', default=1.0, multiple=False, help='Radius of the sphere')

--- a/pyhope/mesh/transform/templates/sphere_box.py
+++ b/pyhope/mesh/transform/templates/sphere_box.py
@@ -51,8 +51,15 @@ def PostDeform(points: npt.NDArray) -> npt.NDArray:  # pragma: no cover
           mapped back to a cube of of size [-4,4]*PostDeform_R0/sqrt(3)
     """
     # Local imports ----------------------------------------
-    from pyhope.readintools.readintools import CreateReal, GetReal
+    import pyhope.output.output as hopout
+    import pyhope.config.config as config
+    from pyhope.readintools.readintools import CreateReal, GetReal, CountOption
     # ------------------------------------------------------
+
+    # Handle the case that the variable was already used
+    config.prms['meshScale']['counter'] = max(config.prms['meshScale']['counter'] - 1, 0)
+    if CountOption('meshScale') and GetReal('meshScale') != 1.:
+        hopout.error('"meshScale" cannot be combined with template "cylinder"')
 
     # Readin parameters
     CreateReal('PostDeform_R0', default=1.0, multiple=False, help='Radius of the sphere')


### PR DESCRIPTION
Some postdeform templates define their own scaling, abort if those are combined with `meshScale`.