### PR TITLE
CI/CD: Add verification / documentation step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,31 @@ jobs:
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 # Code coverage
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
+  documentation:
+    name: Verification / documentation
+    runs-on: ubuntu-latest
+    needs: [examples, healthcheck]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - uses: actions/cache@v5
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      # Install MkDocs
+      - run: pip install mkdocs-material mkdocs-autorefs mkdocs-glightbox
+      # Build documentation
+      - run: mkdocs build
+
+
+# ----------------------------------------------------------------------------------------------------------------------------------------------------
+# Code coverage
+# ----------------------------------------------------------------------------------------------------------------------------------------------------
   coverage:
     name: Verification / coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -72,7 +72,9 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
+      # Install MkDocs
       - run: pip install mkdocs-material mkdocs-autorefs mkdocs-glightbox
+      # Build documentation
       - run: mkdocs build
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,9 @@ numba = [ 'numba'
 homepage = "https://numericsresearchgroup.org"
 documentation = "https://hopr-framework.github.io/PyHOPE"
 repository = "https://github.com/hopr-framework/PyHOPE"
-issues = "https://github.com/hopr-framework/PyHOPE/issues"
-changelog = "https://github.com/hopr-framework/PyHOPE/blob/main/CHANGELOG.md"
+# PyPI is case-sensitive on the following entries
+Issues = "https://github.com/hopr-framework/PyHOPE/issues"
+Changelog = "https://github.com/hopr-framework/PyHOPE/blob/main/CHANGELOG.md"
 
 [project.scripts]
 pyhope = "pyhope.script.pyhope_cli:main"


### PR DESCRIPTION
Documentation was built on every merge to `main` but we did not verify it actually works during CI/CD for pull requests. Add a verification step at the end of each PR pipeline.