### PR TITLE
Mesh: Optionally allow 8-bytes integer (KIND8/int64_t)

### DIFF
--- a/docs/developer-guide/get-the-source.md
+++ b/docs/developer-guide/get-the-source.md
@@ -28,18 +28,15 @@ PyHOPE enforces code quality through three static analysis tools which are wired
 
 ### Tools
 
-**[Ruff](https://docs.astral.sh/ruff/)** is a fast Python linter that consolidates the roles of `flake8`, `black`, `isort`, and many others in a single tool. It checks style and common errors across all `.py` files.  
-
+- **[Ruff](https://docs.astral.sh/ruff/)** is a fast Python linter that consolidates the roles of `flake8`, `black`, `isort`, and many others in a single tool. It checks style and common errors across all `.py` files.  
 !!! note
     Some linter errors can be fixed automatically:
     ```bash
     ruff check --fix
     ```
     Note that `--unsafe-fixes` may silently change program behaviour; `--fix` is guaranteed to be behaviour-preserving.
-
-**[ty](https://github.com/astral-sh/ty)** is a static type checker by Astral. It resolves all imports against the full installed dependency set.
-
-**[vulture](https://github.com/jendrikseipp/vulture)** detects dead code such as unused functions, unreachable branches, and variables that are assigned but never read.
+- **[ty](https://github.com/astral-sh/ty)** is a static type checker by Astral. It resolves all imports against the full installed dependency set.
+- **[vulture](https://github.com/jendrikseipp/vulture)** detects dead code such as unused functions, unreachable branches, and variables that are assigned but never read.
 
 ### Pre-commit Integration
 

--- a/docs/user-guide/parameter-file.md
+++ b/docs/user-guide/parameter-file.md
@@ -23,6 +23,7 @@ PyHOPE reads a self-hosting INI-style parameter file. The following documentatio
     !------------------------------------------------------------------------------
     ProjectName                      =                      ! Name of output files
     OutputFormat                     =                 HDF5 ! Mesh output format [HDF5, VTK, GMSH]
+    OutputBytes                      =                int32 ! Mesh output bytes [int32, int64]
     DebugMesh                        =                    F ! Output debug mesh in XDMF format
     DebugVisu                        =                    F ! Launch the GMSH GUI to visualize the mesh
     !------------------------------------------------------------------------------
@@ -109,6 +110,7 @@ Output parameter controlling the output file name and format.
 | ---------------------------------------- | ---------------------------------- | ------------------------------------- | -------------------------------------- | ---------------------------------------- |
 | `ProjectName`                            | string                             | —                                     | string                                 | Base name for output files. If omitted, a tool- or input-derived name may be used. |
 | `OutputFormat`                           | int &#124; string                  | `HDF5`                                | `HDF5`, `VTK`, `GMSH` (experimental)   | Mesh output format for the generated mesh. `HDF5` is the native PyHOPE format. `VTK` and `GMSH` are provided as output formats for interoperability with other tools. |
+| `OutputBytes`                            | int &#124; string                  | `int32`                               | `int32`, `int64` (experimental)        | Byte size of the mesh output format for the generated mesh. `int32` is the native PyHOPE format. `int64` is provided as output format for large meshes. |
 | `DebugMesh`                              | bool                               | `F`                                   | `T` &#124; `F`                         | Emit an auxiliary XDMF mesh for low-order visualization and troubleshooting.         |
 | `DebugVisu`                              | bool                               | `F`                                   | `T` &#124; `F`                         | Launch the Gmsh GUI after mesh generation for interactive validation and spot checks. |
 

--- a/pyhope/io/io.py
+++ b/pyhope/io/io.py
@@ -26,6 +26,7 @@
 # Standard libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
 from collections import defaultdict
+from enum import Enum, unique
 from typing import Final, cast
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
@@ -41,6 +42,12 @@ import numpy as np
 # ==================================================================================================================================
 
 
+@unique
+class OutputBytes(Enum):
+    KIND4 = 0
+    KIND8 = 1
+
+
 def DefineIO() -> None:
     # Local imports ----------------------------------------
     from pyhope.io.io_vars import MeshFormat
@@ -49,10 +56,13 @@ def DefineIO() -> None:
 
     CreateSection('Output')
     CreateStr('ProjectName', help='Name of output files')
-    CreateIntFromString('OutputFormat'  , default='HDF5', help=f'Mesh output format [{", ".join(s.name for s in MeshFormat)}]')
-    CreateIntOption(    'OutputFormat'  , number=MeshFormat.HDF5.value, name=MeshFormat.HDF5.name)
-    CreateIntOption(    'OutputFormat'  , number=MeshFormat.VTK.value , name=MeshFormat.VTK.name)
-    CreateIntOption(    'OutputFormat'  , number=MeshFormat.GMSH.value, name=MeshFormat.GMSH.name)
+    CreateIntFromString('OutputFormat'  , default=MeshFormat.HDF5.name  , help=f'Mesh output format [{", ".join(s.name for s in MeshFormat)}]')  # noqa: E501
+    CreateIntOption(    'OutputFormat'  , number=MeshFormat.HDF5.value  , name=MeshFormat.HDF5.name)
+    CreateIntOption(    'OutputFormat'  , number=MeshFormat.VTK.value   , name=MeshFormat.VTK.name)
+    CreateIntOption(    'OutputFormat'  , number=MeshFormat.GMSH.value  , name=MeshFormat.GMSH.name)
+    CreateIntFromString('OutputBytes'   , default=OutputBytes.KIND4.name, help=f'Mesh output bytes [{", ".join( s.name for s in OutputBytes)}]')  # noqa: E501
+    CreateIntOption(    'OutputBytes'   , number=OutputBytes.KIND4.value, name=OutputBytes.KIND4.name)
+    CreateIntOption(    'OutputBytes'   , number=OutputBytes.KIND8.value, name=OutputBytes.KIND8.name)
     CreateLogical(      'DebugMesh'     , default=False , help='Output debug mesh in XDMF format')
     CreateLogical(      'DebugVisu'     , default=False , help='Launch the GMSH GUI to visualize the mesh')
 
@@ -69,7 +79,10 @@ def InitIO() -> None:
 
     io_vars.projectname  = GetStr('ProjectName')
     io_vars.outputformat = GetIntFromStr('OutputFormat')
+    # PyHOPE supports both 32 and 64-bit integer outputs
+    io_vars.outputbytes  = np.int32 if GetIntFromStr('OutputBytes') == OutputBytes.KIND4.value else np.int64
 
+    # Debug output
     io_vars.debugmesh    = GetLogical('DebugMesh')
     io_vars.debugvisu    = GetLogical('DebugVisu')
 
@@ -105,9 +118,9 @@ def IO() -> None:
             nSides: Final[int] = len(sides)
             nBCs:   Final[int] = len(bcs)
             # Number of non-unique nodes, vertices, edges
-            nNodes:    Final[int] = np.array(tuple(elem.nodes.size       for elem in elems), dtype=np.int32).sum(dtype=int)  # noqa: E272
-            nVertices: Final[int] = np.array(tuple(elem.type % 10        for elem in elems), dtype=np.int32).sum(dtype=int)  # noqa: E272
-            nEdges:    Final[int] = np.array(tuple(len(edges(elem.type)) for elem in elems), dtype=np.int32).sum(dtype=int)  # noqa: E272
+            nNodes:    Final[int] = np.array(tuple(elem.nodes.size       for elem in elems), dtype=io_vars.outputbytes).sum(dtype=int)  # noqa: E272, E501
+            nVertices: Final[int] = np.array(tuple(elem.type % 10        for elem in elems), dtype=io_vars.outputbytes).sum(dtype=int)  # noqa: E272, E501
+            nEdges:    Final[int] = np.array(tuple(len(edges(elem.type)) for elem in elems), dtype=io_vars.outputbytes).sum(dtype=int)  # noqa: E272, E501
 
             fname = f'{pname}_mesh.h5'
 
@@ -145,7 +158,7 @@ def IO() -> None:
                 f.attrs['nUniqueNodes'  ] = np.max(nodeInfo)
 
                 _ = f.create_dataset('ElemInfo'     , data=elemInfo)
-                _ = f.create_dataset('ElemCounter'  , data=np.array(list(elemCounter.items()), dtype=np.int32))
+                _ = f.create_dataset('ElemCounter'  , data=np.array(list(elemCounter.items()), dtype=io_vars.outputbytes))
                 _ = f.create_dataset('SideInfo'     , data=sideInfo)
                 _ = f.create_dataset('GlobalNodeIDs', data=nodeInfo)
                 _ = f.create_dataset('NodeCoords'   , data=nodeCoords)
@@ -173,7 +186,7 @@ def IO() -> None:
                 # Store boundary information
                 f.attrs['nBCs'          ] = nBCs
                 bcNames = [f'{bc.name:<255}' for bc in bcs]
-                bcTypes = np.array([bc.type  for bc in bcs], dtype=np.int32).reshape(-1, 4)  # noqa: E272
+                bcTypes = np.array([bc.type  for bc in bcs], dtype=io_vars.outputbytes).reshape(-1, 4)  # noqa: E272
 
                 _ = f.create_dataset('BCNames'   , data=np.array(bcNames, dtype='S'))
                 _ = f.create_dataset('BCType'    , data=bcTypes)
@@ -245,6 +258,7 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
                            dict[int, int]
                           ]:
     # Local imports ----------------------------------------
+    import pyhope.io.io_vars as io_vars
     import pyhope.mesh.mesh_vars as mesh_vars
     from pyhope.mesh.fem.fem import getFEMInfo
     from pyhope.mesh.mesh_common import LINTEN
@@ -265,15 +279,15 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
         elemCounter[elemType] = 0
 
     # Pre-allocate arrays
-    elemInfo  = np.zeros((nElems, ELEM.INFOSIZE), dtype=np.int32)
+    elemInfo  = np.zeros((nElems, ELEM.INFOSIZE), dtype=io_vars.outputbytes)
     # sideCount = 0  # elem['Sides'] might work as well
     # nodeCount = 0  # elem['Nodes'] contains the unique nodes
 
     # Calculate the ElemInfo
-    elem_types = np.array(tuple(elem.type                                 for elem in elems), dtype=np.int32)  # noqa: E272
-    elem_zones = np.array(tuple(elem.zone if elem.zone is not None else 1 for elem in elems), dtype=np.int32)  # noqa: E272
-    elem_sides = np.array(tuple(len(elem.sides)                           for elem in elems), dtype=np.int32)  # noqa: E272
-    elem_nodes = np.array(tuple(elem.nodes.size                           for elem in elems), dtype=np.int32)  # noqa: E272
+    elem_types = np.array(tuple(elem.type                                 for elem in elems), dtype=io_vars.outputbytes)  # noqa: E272
+    elem_zones = np.array(tuple(elem.zone if elem.zone is not None else 1 for elem in elems), dtype=io_vars.outputbytes)  # noqa: E272
+    elem_sides = np.array(tuple(len(elem.sides)                           for elem in elems), dtype=io_vars.outputbytes)  # noqa: E272
+    elem_nodes = np.array(tuple(elem.nodes.size                           for elem in elems), dtype=io_vars.outputbytes)  # noqa: E272
 
     # Fill basic element info
     elemInfo[:, ELEM.TYPE] = elem_types
@@ -297,7 +311,7 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
     # Fill the IJK-sorting array
     elemIJK = None
     if hasattr(mesh_vars, 'nElemsIJK'):
-        elemIJK = np.vstack(tuple(cast(int, elem.elemIJK) for elem in elems)).astype(np.int32)
+        elemIJK = np.vstack(tuple(cast(int, elem.elemIJK) for elem in elems)).astype(io_vars.outputbytes)
 
     # Set the global side ID
     highestSideID    = 0
@@ -328,11 +342,11 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
         highestSideID = max(globalSideID, highestSideID)
 
     # Pre-allocate arrays
-    sideInfo   = np.zeros((nSides, SIDE.INFOSIZE), dtype=np.int32)
+    sideInfo   = np.zeros((nSides, SIDE.INFOSIZE), dtype=io_vars.outputbytes)
 
     # Calculate the SideInfo
-    side_types = np.array(tuple(side.sideType     for side in sides), dtype=np.int32)  # noqa: E272
-    side_gloID = np.array(tuple(side.globalSideID for side in sides), dtype=np.int32)  # noqa: E272
+    side_types = np.array(tuple(side.sideType     for side in sides), dtype=io_vars.outputbytes)  # noqa: E272
+    side_gloID = np.array(tuple(side.globalSideID for side in sides), dtype=io_vars.outputbytes)  # noqa: E272
 
     # Fill basic side info
     sideInfo[:, SIDE.TYPE] = side_types
@@ -376,7 +390,7 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
 
     # Pre-allocate arrays
     nNodes: Final[int] = elem_nodes.sum(dtype=int)  # number of non-unique nodes
-    nodeInfo   = np.zeros((nNodes)   , dtype=np.int32)
+    nodeInfo   = np.zeros((nNodes)   , dtype=io_vars.outputbytes)
     nodeCoords = np.zeros((nNodes, 3), dtype=np.float64)
 
     # Pre-compute LINTEN mappings for all element types
@@ -404,7 +418,7 @@ def getMeshInfo() -> tuple[np.ndarray,         # ElemInfo
         nodeCoords[idx] = points[outNodes]
 
     if hasattr(elems[0], 'vertexInfo') and elems[0].vertexInfo is not None:
-        FEMElemInfo, nFEMVertices, vertexInfo, vertexConnectInfo, nFEMEdges, edgeInfo, edgeConnectInfo = getFEMInfo(nodeInfo)
+        FEMElemInfo, nFEMVertices, vertexInfo, vertexConnectInfo, nFEMEdges, edgeInfo, edgeConnectInfo = getFEMInfo()
     else:
         nFEMVertices = nFEMEdges  = 0
         FEMElemInfo  = vertexInfo = vertexConnectInfo = edgeInfo = edgeConnectInfo = None

--- a/pyhope/io/io.py
+++ b/pyhope/io/io.py
@@ -26,7 +26,6 @@
 # Standard libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
 from collections import defaultdict
-from enum import Enum, unique
 from typing import Final, cast
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
@@ -42,15 +41,9 @@ import numpy as np
 # ==================================================================================================================================
 
 
-@unique
-class OutputBytes(Enum):
-    KIND4 = 0
-    KIND8 = 1
-
-
 def DefineIO() -> None:
     # Local imports ----------------------------------------
-    from pyhope.io.io_vars import MeshFormat
+    from pyhope.io.io_vars import MeshFormat, OutputBytes
     from pyhope.readintools.readintools import CreateIntFromString, CreateIntOption, CreateLogical, CreateSection, CreateStr
     # ------------------------------------------------------
 
@@ -60,9 +53,9 @@ def DefineIO() -> None:
     CreateIntOption(    'OutputFormat'  , number=MeshFormat.HDF5.value  , name=MeshFormat.HDF5.name)
     CreateIntOption(    'OutputFormat'  , number=MeshFormat.VTK.value   , name=MeshFormat.VTK.name)
     CreateIntOption(    'OutputFormat'  , number=MeshFormat.GMSH.value  , name=MeshFormat.GMSH.name)
-    CreateIntFromString('OutputBytes'   , default=OutputBytes.KIND4.name, help=f'Mesh output bytes [{", ".join( s.name for s in OutputBytes)}]')  # noqa: E501
-    CreateIntOption(    'OutputBytes'   , number=OutputBytes.KIND4.value, name=OutputBytes.KIND4.name)
-    CreateIntOption(    'OutputBytes'   , number=OutputBytes.KIND8.value, name=OutputBytes.KIND8.name)
+    CreateIntFromString('OutputBytes'   , default=OutputBytes.int32.name, help=f'Mesh output bytes [{", ".join( s.name for s in OutputBytes)}]')  # noqa: E501
+    CreateIntOption(    'OutputBytes'   , number=OutputBytes.int32.value, name=OutputBytes.int32.name)
+    CreateIntOption(    'OutputBytes'   , number=OutputBytes.int64.value, name=OutputBytes.int64.name)
     CreateLogical(      'DebugMesh'     , default=False , help='Output debug mesh in XDMF format')
     CreateLogical(      'DebugVisu'     , default=False , help='Launch the GMSH GUI to visualize the mesh')
 
@@ -80,7 +73,8 @@ def InitIO() -> None:
     io_vars.projectname  = GetStr('ProjectName')
     io_vars.outputformat = GetIntFromStr('OutputFormat')
     # PyHOPE supports both 32 and 64-bit integer outputs
-    io_vars.outputbytes  = np.int32 if GetIntFromStr('OutputBytes') == OutputBytes.KIND4.value else np.int64
+    io_vars.outputbytes  = {io_vars.OutputBytes.int32: np.int32,
+                            io_vars.OutputBytes.int64: np.int64, }[io_vars.OutputBytes(GetIntFromStr('OutputBytes'))]
 
     # Debug output
     io_vars.debugmesh    = GetLogical('DebugMesh')
@@ -222,10 +216,10 @@ def IO() -> None:
 
             # Instantiate the Gmsh cell type mapping
             gmshCellTypes = GMSHCELLTYPES()
+            numNodes      = NumNodesPerCell()
 
             # Print the final output
             hopout.sep()
-            numNodes = NumNodesPerCell()
             for cell in [cell_block for cell_block in mesh.cells if cell_block.type in gmshCellTypes.cellTypes3D]:
                 cellType  = ''.join([s for s in cell.type if not s.isdigit()])
                 cellNodes = numNodes[cellType]

--- a/pyhope/io/io_vars.py
+++ b/pyhope/io/io_vars.py
@@ -40,6 +40,7 @@ from functools import cache
 # ==================================================================================================================================
 projectname  : str                               # Name of output files
 outputformat : int                               # Mesh output format
+outputbytes  : type                              # Mesh output bytes
 
 debugmesh    : bool                              # Mesh output debug mesh
 debugvisu    : bool                              # Enable and show debug output / visualization

--- a/pyhope/io/io_vars.py
+++ b/pyhope/io/io_vars.py
@@ -53,6 +53,12 @@ class MeshFormat(Enum):
     GMSH = 2
 
 
+@unique
+class OutputBytes(Enum):
+    int32 = 0
+    int64 = 1
+
+
 @dataclass(init=False, repr=False, eq=False, slots=False, frozen=True)
 class ELEM:
     INFOSIZE:  int = 6

--- a/pyhope/mesh/fem/fem.py
+++ b/pyhope/mesh/fem/fem.py
@@ -60,6 +60,7 @@ def FEMConnect() -> None:
     """ Generate connectivity information for edges and vertices
     """
     # Local imports ----------------------------------------
+    import pyhope.io.io_vars as io_vars
     import pyhope.mesh.mesh_vars as mesh_vars
     import pyhope.output.output as hopout
     from pyhope.readintools.readintools import CountOption, GetLogical
@@ -114,10 +115,10 @@ def FEMConnect() -> None:
 
     # Build mapping of each node -> set of element indices that include that node
     nodesPerElem = [cast(np.ndarray, elem.nodes)[:cast(int, elem.type) % 10] for elem in elems]
-    elemSizes    = np.array([len(ns) for ns in nodesPerElem], dtype=np.int32)
+    elemSizes    = np.array([len(ns) for ns in nodesPerElem], dtype=io_vars.outputbytes)
 
-    elemIDs      = np.repeat(np.arange(len(elems), dtype=np.int32), elemSizes)
-    allNodes     = np.concatenate(nodesPerElem).astype(np.int32)
+    elemIDs      = np.repeat(np.arange(len(elems), dtype=io_vars.outputbytes), elemSizes)
+    allNodes     = np.concatenate(nodesPerElem).astype(io_vars.outputbytes)
 
     # > Sort by node to form Compressed Sparse Row (CSR) matrix
     sortOrder    = np.argsort(allNodes, kind='stable')
@@ -125,7 +126,7 @@ def FEMConnect() -> None:
 
     # > Build CSR offsets
     uniqueNodes, nCSR = np.unique(allNodes[sortOrder], return_counts=True)
-    offsetsCSR        = np.empty(len(uniqueNodes) + 1, dtype=np.int32)
+    offsetsCSR        = np.empty(len(uniqueNodes) + 1, dtype=io_vars.outputbytes)
     offsetsCSR[0]     = 0
     np.cumsum(nCSR, out=offsetsCSR[1:])
 
@@ -153,7 +154,7 @@ def FEMConnect() -> None:
 
     # > nodeFirstArr[n] = canonical representative of node n (identity for non-periodic nodes)
     maxNode      = int(allNodes.max())
-    nodeFirstArr = np.arange(maxNode + 1, dtype=np.int32)
+    nodeFirstArr = np.arange(maxNode + 1, dtype=io_vars.outputbytes)
     for v, rep in nodeFirst.items():
         nodeFirstArr[v] = rep
 
@@ -256,7 +257,7 @@ def FEMConnect() -> None:
             edgeCanonical[node] = canonical_rep
 
     # Build nodeFEMVertex
-    nodeFEMVertexArr = np.empty(maxNode + 1, dtype=np.int32)
+    nodeFEMVertexArr = np.empty(maxNode + 1, dtype=io_vars.outputbytes)
     for node in uniqueNodes:
         iNode = int(node)
         nodeFEMVertexArr[iNode] = FEMNodeMapping[int(nodeFirstArr[iNode])]
@@ -306,14 +307,14 @@ def FEMConnect() -> None:
         elems[elemID].edgeInfo[locEdge] = (locEdge, FEMEdgeMapping[edgeKey], edgePair, edgeNodes)
 
 
-def getFEMInfo(nodeInfo: npt.NDArray) -> tuple[npt.NDArray,  # FEMElemInfo
-                                               int,          # nVertices
-                                               npt.NDArray,  # VertexInfo
-                                               npt.NDArray,  # VertexConnectInfo
-                                               int,          # nEdges
-                                               npt.NDArray,  # EdgeInfo
-                                               npt.NDArray   # EdgeConnectInfo
-                                              ]:
+def getFEMInfo() -> tuple[npt.NDArray,  # FEMElemInfo
+                          int,          # nVertices
+                          npt.NDArray,  # VertexInfo
+                          npt.NDArray,  # VertexConnectInfo
+                          int,          # nEdges
+                          npt.NDArray,  # EdgeInfo
+                          npt.NDArray   # EdgeConnectInfo
+                         ]:
     """ Extract the FEM connectivity information and return five arrays
 
      - FEMElemInfo      : [offsetIndEdge, lastIndEdge, offsetIndVertex, lastIndVertex]
@@ -323,6 +324,7 @@ def getFEMInfo(nodeInfo: npt.NDArray) -> tuple[npt.NDArray,  # FEMElemInfo
      - EdgeConnectInfo  : [nbElemID, nbLocEdgeID]
     """
     # Local imports ----------------------------------------
+    import pyhope.io.io_vars as io_vars
     import pyhope.mesh.mesh_vars as mesh_vars
     # ------------------------------------------------------
 
@@ -336,9 +338,9 @@ def getFEMInfo(nodeInfo: npt.NDArray) -> tuple[npt.NDArray,  # FEMElemInfo
     # > Build flat arrays of all vertex occurrences
     # > > Same order as the elements
     nOccVertex = sum(len(cast(dict, elem.vertexInfo)) for elem in elems)
-    occVertID  = np.empty(nOccVertex, dtype=np.int32)   # FEMVertexID      per occurrence
-    occElemID  = np.empty(nOccVertex, dtype=np.int32)   # Element index    per occurrence
-    occLocNode = np.empty(nOccVertex, dtype=np.int32)   # Local node index per occurrence
+    occVertID  = np.empty(nOccVertex, dtype=io_vars.outputbytes)   # FEMVertexID      per occurrence
+    occElemID  = np.empty(nOccVertex, dtype=io_vars.outputbytes)   # Element index    per occurrence
+    occLocNode = np.empty(nOccVertex, dtype=io_vars.outputbytes)   # Local node index per occurrence
 
     idx = 0
     for elemID, elem in enumerate(elems):
@@ -356,11 +358,11 @@ def getFEMInfo(nodeInfo: npt.NDArray) -> tuple[npt.NDArray,  # FEMElemInfo
 
     # > Pre-allocate output arrays
     nVertConnTotal = sum(len(idxs) * (len(idxs) - 1) for idxs in groups.values())
-    vertexInfoArr  = np.empty((nOccVertex,     3), dtype=np.int32)  # [FEMVertexID, offset, last]
-    vertexConnArr  = np.empty((nVertConnTotal, 2), dtype=np.int32)  # [nbElemID, nbLocVertexID]
+    vertexInfoArr  = np.empty((nOccVertex,     3), dtype=io_vars.outputbytes)  # [FEMVertexID, offset, last]
+    vertexConnArr  = np.empty((nVertConnTotal, 2), dtype=io_vars.outputbytes)  # [nbElemID, nbLocVertexID]
 
     # Initialize FEM element information
-    FEMElemInfo  = np.zeros((len(elems), 4), dtype=np.int32)
+    FEMElemInfo  = np.zeros((len(elems), 4), dtype=io_vars.outputbytes)
 
     connOffset   = 0
     vertexOffset = 0  # cumulative vertex count for FEMElemInfo
@@ -411,11 +413,11 @@ def getFEMInfo(nodeInfo: npt.NDArray) -> tuple[npt.NDArray,  # FEMElemInfo
     # > Build flat arrays of all raw edge occurrences
     # > > Same order as the elements
     nOccEdge      = sum(len(cast(dict, elem.edgeInfo)) for elem in elems)
-    occEdgeID     = np.empty(nOccEdge, dtype=np.int32)   # FEMEdgeID        per occurrence
-    occElemID     = np.empty(nOccEdge, dtype=np.int32)   # Element index    per occurrence
-    occLocEdge    = np.empty(nOccEdge, dtype=np.int32)   # Local edge index per occurrence
-    occVertexPair = [(0, 0)]  * nOccEdge                 # FEM vertex pair  per occurrence (canonical)
-    occNodes      = [(0, 0)]  * nOccEdge                 # Edge node pair   per occurrence
+    occEdgeID     = np.empty(nOccEdge, dtype=io_vars.outputbytes)   # FEMEdgeID        per occurrence
+    occElemID     = np.empty(nOccEdge, dtype=io_vars.outputbytes)   # Element index    per occurrence
+    occLocEdge    = np.empty(nOccEdge, dtype=io_vars.outputbytes)   # Local edge index per occurrence
+    occVertexPair = [(0, 0)]  * nOccEdge                            # FEM vertex pair  per occurrence (canonical)
+    occNodes      = [(0, 0)]  * nOccEdge                            # Edge node pair   per occurrence
 
     idx = 0
     for elemID, elem in enumerate(elems):
@@ -437,8 +439,8 @@ def getFEMInfo(nodeInfo: npt.NDArray) -> tuple[npt.NDArray,  # FEMElemInfo
 
     # > Pre-allocate output arrays
     nEdgeConnTotal = sum(len(idxs) * (len(idxs) - 1) for idxs in groups_e.values())
-    edgeInfoArr    = np.empty((nOccEdge,        3), dtype=np.int32)  # [FEMEdgeID, offset, last]
-    edgeConn_arr   = np.empty((nEdgeConnTotal,  2), dtype=np.int32)  # [nbElemID, nbLocEdgeID]
+    edgeInfoArr    = np.empty((nOccEdge,        3), dtype=io_vars.outputbytes)  # [FEMEdgeID, offset, last]
+    edgeConn_arr   = np.empty((nEdgeConnTotal,  2), dtype=io_vars.outputbytes)  # [nbElemID, nbLocEdgeID]
 
     connOffset   = 0
     edgeOffset   = 0  # Cumulative edge count for FEMElemInfo
@@ -490,9 +492,9 @@ def getFEMInfo(nodeInfo: npt.NDArray) -> tuple[npt.NDArray,  # FEMElemInfo
 
     # Trim connectivity arrays to actual written size
     vertexInfo = vertexInfoArr
-    vertexConn = vertexConnArr[:vertConnOffset] if vertConnOffset > 0 else np.empty((0, 2), dtype=np.int32)
+    vertexConn = vertexConnArr[:vertConnOffset] if vertConnOffset > 0 else np.empty((0, 2), dtype=io_vars.outputbytes)
 
     edgeInfo   = edgeInfoArr
-    edgeConn   = edgeConn_arr[:edgeConnOffset]  if edgeConnOffset > 0 else np.empty((0, 2), dtype=np.int32)  # noqa: E272
+    edgeConn   = edgeConn_arr[:edgeConnOffset]  if edgeConnOffset > 0 else np.empty((0, 2), dtype=io_vars.outputbytes)  # noqa: E272
 
     return FEMElemInfo, nFEMVertices, vertexInfo, vertexConn, nFEMEdges, edgeInfo, edgeConn

--- a/pyhope/mesh/mesh.py
+++ b/pyhope/mesh/mesh.py
@@ -183,15 +183,21 @@ def GenerateMesh() -> None:
         Mode 1 - Use internal mesh generator
         Mode 2 - Readin external mesh through GMSH
     """
+    # Standard libraries -----------------------------------
+    import math
+    import numpy as np
     # Local imports ----------------------------------------
+    import pyhope.io.io_vars as io_vars
     import pyhope.mesh.mesh_vars as mesh_vars
     import pyhope.output.output as hopout
+    from pyhope.io.io_gmsh import GMSHCELLTYPES
     from pyhope.mesh.extrude.mesh_extrude import MeshExtrude
     from pyhope.mesh.mesh_builtin import MeshCartesian
     from pyhope.mesh.mesh_external import MeshExternal
     from pyhope.mesh.mesh_vars import MeshMode
     from pyhope.mesh.topology.mesh_splittohex import MeshSplitToHex
     from pyhope.mesh.topology.mesh_topology import MeshChangeElemType
+    from pyhope.meshio.meshio_nodes import NumNodesPerCell
     # ------------------------------------------------------
 
     hopout.separator()
@@ -218,6 +224,20 @@ def GenerateMesh() -> None:
     for cellType in mesh.cells:
         if any(s in cellType.type for s in mesh_vars.ELEMTYPE.type):
             nElems += mesh.get_cells_type(cellType.type).shape[0]
+
+    # Instantiate the Gmsh cell type mapping
+    gmshCellTypes = GMSHCELLTYPES()
+    numNodes      = NumNodesPerCell()
+
+    # Final number of nodes
+    nNodes = 0
+    for cell in [cell_block for cell_block in mesh.cells if cell_block.type in gmshCellTypes.cellTypes3D]:
+        cellType  = ''.join([s for s in cell.type if not s.isdigit()])
+        nNodes += len(cell)*numNodes[cellType]
+
+    # Check if nGlobalNodes fits in the mesh format
+    if math.ceil(nNodes.bit_length() / 8.0) > np.dtype(io_vars.outputbytes).itemsize:
+        hopout.error(f'Mesh size too large for selected OutputBytes "{io_vars.outputbytes.__name__}". Try increasing OutputBytes!')
 
     hopout.routine(f'Generated mesh with {nElems} cells')
     # hopout.sep()

--- a/pyhope/mesh/mesh_builtin.py
+++ b/pyhope/mesh/mesh_builtin.py
@@ -380,14 +380,14 @@ def MeshCartesian() -> meshio.Mesh:
     #                         gmsh.option.getNumber('Mesh.NbHexahedra')), dtype=int)
     gmshTypes = gmsh.model.mesh.getElementTypes()
     gmshElems = np.asarray([(elemName, order) for type                          in gmshTypes                                     # noqa: E272
-                                               for elemName, dim, order, _, _, _ in [gmsh.model.mesh.getElementProperties(type)]  # noqa: E272
+                                              for elemName, dim, order, _, _, _ in [gmsh.model.mesh.getElementProperties(type)]  # noqa: E272
                               if dim == 3])
     if not np.any(gmshElems):
         hopout.error('Generated mesh does not contain volume elements, exiting...')
 
     # Consistency check if the mesh elements have the correct order
-    gmshIssue  = np.asarray([(elemName, order) for type                          in gmshTypes                                     # noqa: E272
-                                               for elemName, dim, order, _, _, _ in [gmsh.model.mesh.getElementProperties(type)]  # noqa: E272
+    gmshIssue = np.asarray([(elemName, order) for type                          in gmshTypes                                     # noqa: E272
+                                              for elemName, dim, order, _, _, _ in [gmsh.model.mesh.getElementProperties(type)]  # noqa: E272
                               if dim == 3 and order != mesh_vars.nGeo])
 
     if gmshIssue.size > 0:

--- a/pyhope/mesh/mesh_sort.py
+++ b/pyhope/mesh/mesh_sort.py
@@ -72,6 +72,9 @@ def UpdateElemID(elems         : list,
                  bar           : type,
                  nElemsIJK     : Optional[npt.NDArray] = None,
                  ) -> tuple[list, list]:
+    # Local imports ----------------------------------------
+    import pyhope.io.io_vars as io_vars
+    # ------------------------------------------------------
 
     totalElems = len(elems)
     totalSides = len(sides)
@@ -96,7 +99,7 @@ def UpdateElemID(elems         : list,
             k =  newElemID                                       // (nElemsIJK[0] * nElemsIJK[1])
             j = (newElemID - k * nElemsIJK[0] * nElemsIJK[1])    //  nElemsIJK[0]
             i =  newElemID - k * nElemsIJK[0] * nElemsIJK[1] - j *   nElemsIJK[0]
-            elem.elemIJK = np.array([i+1, j+1, k+1], dtype=np.int32)
+            elem.elemIJK = np.array([i+1, j+1, k+1], dtype=io_vars.outputbytes)
 
         sorted_elems[newElemID] = elem
 


### PR DESCRIPTION
The native HOPR/PyHOPE HDF5 format specifies 4-byte integers for all arrays. However, this overflows for large meshes. Add an optional 8-byte integer output and checks to abort if meshes overflow the 4-byte boundary.