### PR TITLE
CGNS Reader: Read fully-hexahedral unstructured ICEM CGNS meshes

### DIFF
--- a/pyhope/mesh/reader/reader_gmsh.py
+++ b/pyhope/mesh/reader/reader_gmsh.py
@@ -463,16 +463,27 @@ def BCCGNS_Unstructured(  mesh:     meshio.Mesh,
         elif f'{zoneBC}/PointList' in zone['ZoneBC']:
             cgnsBC = sorted(int(s.squeeze()) for s in zone['ZoneBC'][zoneBC]['PointList'][' data'])
 
-            # Identify how surface elements are stored
-            surface_key = 'GridShells' if 'GridShells' in zone else 'SurfaceElements' if 'SurfaceElements' in zone else None
-            if not surface_key:
+            # Identify how surface elements are stored and get the location of the BC faces
+            if   'GridShells'      in zone:  # noqa: E271, E272
+                surface_key = 'GridShells'
+                cgnsGridLoc = bytes(zone['ZoneBC'][zoneBC]['GridLocation'][' data']).decode('ascii')
+            elif 'SurfaceElements' in zone:
+                surface_key = 'SurfaceElements'
+                cgnsGridLoc = bytes(zone['ZoneBC'][zoneBC]['GridLocation'][' data']).decode('ascii')
+            elif 'FamilyName'      in zone['ZoneBC'][zoneBC]:  # noqa: E272
+                surface_key = bytes(zone['ZoneBC'][zoneBC]['FamilyName'][' data']).decode('ascii')
+                cgnsGridLoc = 'FamilyName'
+                # ICEM uses the FamilyName as BC name
+                zoneBC      = surface_key
+                # FIXME: How can we find out the elemType for ICEM CGNS meshes?
+                if zone[surface_key]['ElementConnectivity'][' data'].shape[0] % \
+                    (int(zone[surface_key]['ElementRange'][' data'][1])-int(zone[surface_key]['ElementRange'][' data'][0])+1) != 0:
+                    hopout.error('PyHOPE currently only supports fully hexahedral ICEM CGNS meshes, exiting...')
+            else:
                 hopout.error('Format of BC implementation for FaceCenters not recognized, exiting...')
 
             cgnsShells  =     zone[surface_key]['ElementConnectivity'][' data']
             nShells     = int(zone[surface_key]['ElementRange'       ][' data'][0])
-
-            # Get the location of the BC faces
-            cgnsGridLoc = bytes(zone['ZoneBC'][zoneBC]['GridLocation'][' data']).decode('ascii')
             cgns_set    = set(cgnsBC)
 
             # Read the surface elements, one at a time
@@ -480,34 +491,49 @@ def BCCGNS_Unstructured(  mesh:     meshio.Mesh,
 
             # Loop over all elements and collect centroids
             while count < cgnsShells.shape[0]:
-                elemType = ElemTypes(cgnsShells[count])
-                nNodes   = int(elemType['Nodes'])
+                match cgnsGridLoc:
+                    case 'Vertex':
+                        elemType = ElemTypes(cgnsShells[count])
+                        nNodes   = int(elemType['Nodes'])
 
-                corners  = cgnsShells[count+1:count+nNodes+1]
+                        # Check if corners can form a subset of cgnsBC
+                        corners     = cgnsShells[count+1:count+nNodes+1]
+                        corners_set = {int(s) for s in corners}
+                        if corners_set.issubset(cgns_set):
+                            BCpoints = bpoints[[s-1 for s in corners]]
+                            # print(BCpoints, BCpoints.shape)
+                            quadCenters.append(np.mean(BCpoints, axis=0))
+                        count += nNodes + 1
 
-                if cgnsGridLoc == 'Vertex':
-                    # Check if corners can form a subset of cgnsBC
-                    corners_set = {int(s) for s in corners}
-                    if corners_set.issubset(cgns_set):
+                    case 'FaceCenter':
+                        elemType = ElemTypes(cgnsShells[count])
+                        nNodes   = int(elemType['Nodes'])
+
+                        # Check if corners can form a subset of cgnsBC
+                        corners  = cgnsShells[count+1:count+nNodes+1]
+                        if nShells in cgns_set:
+                            BCpoints = bpoints[[s-1 for s in corners]]
+
+                            # For high-order elements, we only consider the 3/4 corner nodes for the centroid
+                            match len(BCpoints):
+                                case 3 | 6:       # triangle, triangle6
+                                    triaCenters.append(np.mean(BCpoints[:3], axis=0))
+                                case 4 | 8 | 9:   # quad, quad8, quad9
+                                    quadCenters.append(np.mean(BCpoints[:4], axis=0))
+                                case _:
+                                    hopout.error('Unsupported number of corners for shell elements, exiting...')
+
+                        nShells += 1
+                        count   += nNodes + 1
+
+                    case 'FamilyName':
+                        # FIXME: How can we find out the elemType for ICEM CGNS meshes?
+                        nNodes   = 4
+                        # Check if corners can form a subset of cgnsBC
+                        corners  = cgnsShells[count  :count+nNodes  ]
                         BCpoints = bpoints[[s-1 for s in corners]]
                         quadCenters.append(np.mean(BCpoints, axis=0))
-                    count += nNodes + 1
-
-                elif cgnsGridLoc == 'FaceCenter':
-                    if nShells in cgns_set:
-                        BCpoints = bpoints[[s-1 for s in corners]]
-
-                        # For high-order elements, we only consider the 3/4 corner nodes for the centroid
-                        match len(BCpoints):
-                            case 3 | 6:       # triangle, triangle6
-                                triaCenters.append(np.mean(BCpoints[:3], axis=0))
-                            case 4 | 8 | 9:   # quad, quad8, quad9
-                                quadCenters.append(np.mean(BCpoints[:4], axis=0))
-                            case _:
-                                hopout.error('Unsupported number of corners for shell elements, exiting...')
-
-                    nShells += 1
-                    count   += nNodes + 1
+                        count += nNodes
 
         # Data attached to the zoneBC node
         elif f'{zoneBC}/ElementList' in zone['ZoneBC']:


### PR DESCRIPTION
ICEM CGNS stores the BC information with the `FamilyName`. Implement a basic reader for fully-hexahedral unstructured ICEM CGNS meshes.

Known issues:
- [ ] Currently, PyHOPE assumes quad surface elements as there seems to be no way to determine the face type.