### PR TITLE
Gmsh: Update to v4.15.2

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -98,7 +98,7 @@ runs:
         source .venv/bin/activate
 
         if [[ "${{ inputs.minimal }}" != "true" ]]; then
-          uv pip install --no-cache-dir https://gitlab.iag.uni-stuttgart.de/libs/python-gmsh/-/raw/master/gmsh-4.15.1.post1-py3-none-linux_x86_64.whl
+          uv pip install --no-cache-dir https://gitlab.iag.uni-stuttgart.de/libs/python-gmsh/-/raw/master/gmsh-4.15.2.post1-py3-none-linux_x86_64.whl
           uv pip install --no-cache-dir -e .
         fi
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,7 +86,7 @@ variables:
   - uv venv .venv
   - source .venv/bin/activate
   # Regression checks needs NRG Gmsh, pre-install it
-  - uv pip install --no-cache-dir https://gitlab.iag.uni-stuttgart.de/libs/python-gmsh/-/raw/master/gmsh-4.15.1.post1-py3-none-linux_x86_64.whl
+  - uv pip install --no-cache-dir https://gitlab.iag.uni-stuttgart.de/libs/python-gmsh/-/raw/master/gmsh-4.15.2.post1-py3-none-linux_x86_64.whl
   # Install all pre-requisites
   - uv pip install --no-cache-dir -e .
   # Install coverage

--- a/.gmsh/build_macos.py
+++ b/.gmsh/build_macos.py
@@ -149,13 +149,13 @@ ZLIB_URL     = ('madler', 'zlib')
 
 # TK
 TK_DIR       = os.path.join(WORK_DIR, 'tk')
-TK_VERSION   = '8.6.16'
-TK_URL       = ('https://sourceforge.net/projects/tcl/files/Tcl/', r'href="[^"]+/Tcl/(\d+\.\d+\.\d+)/"')
+TK_VERSION   = '9.0.3'
+# TK_URL       = ('https://sourceforge.net/projects/tcl/files/Tcl/', r'href="[^"]+/Tcl/(\d+\.\d+\.\d+)/"')
 
 # TCL
 TCL_DIR      = os.path.join(WORK_DIR, 'tcl')
-TCL_VERSION  = '8.6.16'
-TCL_URL      = ('https://sourceforge.net/projects/tcl/files/Tcl/', r'href="[^"]+/Tcl/(\d+\.\d+\.\d+)/"')
+TCL_VERSION  = '9.0.3'
+# TCL_URL      = ('https://sourceforge.net/projects/tcl/files/Tcl/', r'href="[^"]+/Tcl/(\d+\.\d+\.\d+)/"')
 
 # CGNS
 CGNS_DIR     = os.path.join(WORK_DIR, 'CGNS')
@@ -164,12 +164,12 @@ CGNS_URL     = ('CGNS', 'CGNS', 'v')
 
 # OpenCASCADE
 OCC_DIR      = os.path.join(WORK_DIR, 'occt')
-OCC_VERSION  = 'V7_9_2'
-OCC_URL      = ('Open-Cascade-SAS', 'OCCT', 'V')
+OCC_VERSION  = 'V7_9_3'
+# OCC_URL      = ('Open-Cascade-SAS', 'OCCT', 'V')
 
 # FreeType
 FREETYPE_VERSION = '2.14.1'
-FREETYPE_DIR = os.path.join(WORK_DIR, 'freetype')
+FREETYPE_DIR     = os.path.join(WORK_DIR, 'freetype')
 FREETYPE_URL     = ('freetype', 'freetype2')
 
 # libXFT
@@ -191,7 +191,8 @@ LIBJPEG_TURBO_URL     = ('libjpeg-turbo', 'libjpeg-turbo')
 FLTK_DIR     = os.path.join(WORK_DIR, 'fltk')
 FLTK_VERSION = '1.3.11'
 # FLTK_VERSION = '1.4.0'  # Currently broken, produces segfault
-FLTK_URL     = ('fltk', 'fltk', '', r'^release-1\.3\.')
+# FLTK_URL     = ('fltk', 'fltk', '', r'^release-1\.3\.')
+FLTK_URL     = ('fltk', 'fltk')
 
 # gperf
 GPERF_VERSION = "3.3"
@@ -207,7 +208,7 @@ FONTCONFIG_URL     = ('https://www.freedesktop.org/software/fontconfig/release/'
 # GLU_VERSION  = '9.0.3'
 
 # Gmsh
-GMSH_VERSION = '4.15.1'
+GMSH_VERSION = '4.15.2'
 GMSH_PATCH   = '1'
 GMSH_FULLVER = f'{GMSH_VERSION}.post{GMSH_PATCH}' if GMSH_PATCH else GMSH_VERSION
 GMSH_STRING  = 'gmsh_{}'.format(GMSH_VERSION.replace('.', '_'))
@@ -289,10 +290,10 @@ print_header('RESOLVING DEPENDENCY VERSIONS...')
 # HDF5_VERSION needs to match h5py - do not automatically update
 ZLIB_VERSION          = get_latest_version(lambda: _github_latest_tag (*ZLIB_URL          )                 , 'zlib'         , ZLIB_VERSION)           # noqa: E211, E501
 # MINIZIP_VERSION       = get_latest_version(lambda: _github_latest_tag (*MINIZIP_URL       )                 , 'minizip-ng'   , MINIZIP_VERSION)        # noqa: E211, E501
-TCL_VERSION           = get_latest_version(lambda: _scrape_latest     (*TK_URL           )                  , 'TCL'          , TCL_VERSION)            # noqa: E211, E501
-TK_VERSION            = get_latest_version(lambda: _scrape_latest     (*TCL_URL          )                  , 'TK'           , TK_VERSION)             # noqa: E211, E501
+# TCL_VERSION           = get_latest_version(lambda: _scrape_latest     (*TK_URL           )                  , 'TCL'          , TCL_VERSION)            # noqa: E211, E501
+# TK_VERSION            = get_latest_version(lambda: _scrape_latest     (*TCL_URL          )                  , 'TK'           , TK_VERSION)             # noqa: E211, E501
 CGNS_VERSION          = get_latest_version(lambda: _github_latest_tag (*CGNS_URL         )                  , 'CGNS'         , CGNS_VERSION)           # noqa: E211, E501
-OCC_VERSION           = get_latest_version(lambda: _github_latest_tag (*OCC_URL          ).replace('.', '_'), 'OpenCascade'  , OCC_VERSION)            # noqa: E211, E501
+# OCC_VERSION           = get_latest_version(lambda: _github_latest_tag (*OCC_URL          ).replace('.', '_'), 'OpenCascade'  , OCC_VERSION)            # noqa: E211, E501
 FREETYPE_VERSION      = get_latest_version(lambda: _github_latest_tag (*FREETYPE_URL     )                  , 'FreeType'     , FREETYPE_VERSION)       # noqa: E211, E501
 LIBXFT_VERSION        = get_latest_version(lambda: _scrape_latest     (*LIBXFT_URL       )                  , 'LibXFT'       , LIBXFT_VERSION)         # noqa: E211, E501
 LIBPNG_VERSION        = get_latest_version(lambda: _github_latest_tag (*LIBPNG_URL       )                  , 'LibPNG'       , LIBPNG_VERSION)         # noqa: E211, E501

--- a/.gmsh/build_manylinux.py
+++ b/.gmsh/build_manylinux.py
@@ -67,7 +67,7 @@ def get_latest_version(fetch_fn: Callable, name: str, fallback: str) -> str:
     try:
         version = fetch_fn()
         if version:
-            print_step(f' {name:<13} → resolved: {version}')
+            print_step(f' {name:<13} → resolved: {version}' + ('' if version == fallback else f' (from {fallback})'))
             return version
     except Exception as exc:
         print_step(f' {name:<13} → version check failed ({exc}), using fallback: {fallback}')
@@ -150,13 +150,13 @@ ZLIB_URL     = ('madler', 'zlib')
 
 # TK
 TK_DIR       = os.path.join(WORK_DIR, 'tk')
-TK_VERSION   = '8.6.16'
-TK_URL       = ('https://sourceforge.net/projects/tcl/files/Tcl/', r'href="[^"]+/Tcl/(\d+\.\d+\.\d+)/"')
+TK_VERSION   = '9.0.3'
+# TK_URL       = ('https://sourceforge.net/projects/tcl/files/Tcl/', r'href="[^"]+/Tcl/(\d+\.\d+\.\d+)/"')
 
 # TCL
 TCL_DIR      = os.path.join(WORK_DIR, 'tcl')
-TCL_VERSION  = '8.6.16'
-TCL_URL      = ('https://sourceforge.net/projects/tcl/files/Tcl/', r'href="[^"]+/Tcl/(\d+\.\d+\.\d+)/"')
+TCL_VERSION  = '9.0.3'
+# TCL_URL      = ('https://sourceforge.net/projects/tcl/files/Tcl/', r'href="[^"]+/Tcl/(\d+\.\d+\.\d+)/"')
 
 # CGNS
 CGNS_DIR     = os.path.join(WORK_DIR, 'CGNS')
@@ -165,8 +165,8 @@ CGNS_URL     = ('CGNS', 'CGNS', 'v')
 
 # OpenCASCADE
 OCC_DIR      = os.path.join(WORK_DIR, 'occt')
-OCC_VERSION  = 'V7_9_2'
-OCC_URL      = ('Open-Cascade-SAS', 'OCCT', 'V')
+OCC_VERSION  = 'V7_9_3'
+# OCC_URL      = ('Open-Cascade-SAS', 'OCCT', 'V')
 
 # FreeType
 FREETYPE_VERSION = '2.14.1'
@@ -209,7 +209,7 @@ FONTCONFIG_URL     = ('https://www.freedesktop.org/software/fontconfig/release/'
 # GLU_VERSION  = '9.0.3'
 
 # Gmsh
-GMSH_VERSION = '4.15.1'
+GMSH_VERSION = '4.15.2'
 GMSH_PATCH   = '1'
 GMSH_FULLVER = f'{GMSH_VERSION}.post{GMSH_PATCH}' if GMSH_PATCH else GMSH_VERSION
 GMSH_STRING  = 'gmsh_{}'.format(GMSH_VERSION.replace('.', '_'))
@@ -291,10 +291,10 @@ print_header('RESOLVING DEPENDENCY VERSIONS...')
 # HDF5_VERSION needs to match h5py - do not automatically update
 ZLIB_VERSION          = get_latest_version(lambda: _github_latest_tag (*ZLIB_URL          )                 , 'zlib'         , ZLIB_VERSION)           # noqa: E211, E501
 # MINIZIP_VERSION       = get_latest_version(lambda: _github_latest_tag (*MINIZIP_URL       )                 , 'minizip-ng'   , MINIZIP_VERSION)        # noqa: E211, E501
-TCL_VERSION           = get_latest_version(lambda: _scrape_latest     (*TK_URL           )                  , 'TCL'          , TCL_VERSION)            # noqa: E211, E501
-TK_VERSION            = get_latest_version(lambda: _scrape_latest     (*TCL_URL          )                  , 'TK'           , TK_VERSION)             # noqa: E211, E501
+# TCL_VERSION           = get_latest_version(lambda: _scrape_latest     (*TK_URL           )                  , 'TCL'          , TCL_VERSION)            # noqa: E211, E501
+# TK_VERSION            = get_latest_version(lambda: _scrape_latest     (*TCL_URL          )                  , 'TK'           , TK_VERSION)             # noqa: E211, E501
 CGNS_VERSION          = get_latest_version(lambda: _github_latest_tag (*CGNS_URL         )                  , 'CGNS'         , CGNS_VERSION)           # noqa: E211, E501
-OCC_VERSION           = get_latest_version(lambda: _github_latest_tag (*OCC_URL          ).replace('.', '_'), 'OpenCascade'  , OCC_VERSION)            # noqa: E211, E501
+# OCC_VERSION           = get_latest_version(lambda: _github_latest_tag (*OCC_URL          ).replace('.', '_'), 'OpenCascade'  , OCC_VERSION)            # noqa: E211, E501
 FREETYPE_VERSION      = get_latest_version(lambda: _github_latest_tag (*FREETYPE_URL     )                  , 'FreeType'     , FREETYPE_VERSION)       # noqa: E211, E501
 LIBXFT_VERSION        = get_latest_version(lambda: _scrape_latest     (*LIBXFT_URL       )                  , 'LibXFT'       , LIBXFT_VERSION)         # noqa: E211, E501
 LIBPNG_VERSION        = get_latest_version(lambda: _github_latest_tag (*LIBPNG_URL       )                  , 'LibPNG'       , LIBPNG_VERSION)         # noqa: E211, E501

--- a/pyhope/check/check_health.py
+++ b/pyhope/check/check_health.py
@@ -27,7 +27,9 @@
 # ----------------------------------------------------------------------------------------------------------------------------------
 import json
 import urllib.request
+from dataclasses import dataclass
 from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from typing import Optional, Union
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -40,6 +42,12 @@ from typing import Optional, Union
 # Local definitions
 # ----------------------------------------------------------------------------------------------------------------------------------
 # ==================================================================================================================================
+
+
+@dataclass(frozen=True, slots=True)
+class PackageReason:
+    name: str
+    spec: SpecifierSet
 
 
 def PyPIVersion(package: str, timeout: int = 10) -> Optional[Version]:
@@ -267,7 +275,7 @@ def PackageHealth(   pkg:      str,
                      version:  Union[Version, None],
                      pypiver:  Union[Version, None],  # noqa: E272
                      optional: Optional[bool] = False,
-                     reason:   Optional[str]  = None,
+                     reason:   Optional['PackageReason'] = None,
                  ) -> None:
     # Local imports ----------------------------------------
     import pyhope.output.output as hopout
@@ -278,8 +286,8 @@ def PackageHealth(   pkg:      str,
                 hopout.printtest(f'{pkg} [v{version}] is up-to-date',                  hopout.Symbols.OK)
             else:
                 hopout.printtest(f'{pkg} [v{version}] is outdated (PyPI: v{pypiver})', hopout.Symbols.WARN)
-                if reason:
-                    hopout.routine(f' {hopout.Symbols.INFO} constrained by {reason}')
+                if reason and (version in reason.spec) and (pypiver not in reason.spec):
+                    hopout.routine(f' {hopout.Symbols.INFO} constrained by {reason.name} ({reason.spec})')
         except Exception:  # pragma: no cover
             hopout.printtest(f'{pkg} [v{version}] is installed (PyPI: v{pypiver}) -- unable to compare reliably', hopout.Symbols.WARN)  # noqa: E501
     elif version:  # pragma: no cover
@@ -321,7 +329,7 @@ def CheckHealth() -> None:
     for p in pkgs:
         name, spec = _PackageExtractRequirement(p)
         if spec:
-            pkg_reasons[name] = program
+            pkg_reasons[name] = PackageReason(name=program, spec=SpecifierSet(str(spec)))
 
         # Also check requirements of installed dependencies to find downstream constraints
         dep_name = _PackageExtractName(p)
@@ -330,7 +338,7 @@ def CheckHealth() -> None:
                 for dep in (importlib_metadata.requires(dep_name) or []):
                     sub_name, sub_spec = _PackageExtractRequirement(dep)
                     if sub_spec:
-                        pkg_reasons[sub_name] = f'{dep_name}{sub_spec}'
+                        pkg_reasons[sub_name] = PackageReason(name=dep_name, spec=SpecifierSet(str(sub_spec)))
             except Exception:
                 pass
 

--- a/pyhope/common/common_vars.py
+++ b/pyhope/common/common_vars.py
@@ -143,7 +143,7 @@ class Gitlab:
     LIB_PROJECT: str = '797'
     LIB_VERSION: dict[str, dict[str, str]] = {  # noqa: RUF012
         'linux': {
-            'x86_64' : '4.15.1.post1',
+            'x86_64' : '4.15.2.post1',
             'aarch64': '4.13.1.post1'
         },
         'darwin': {
@@ -152,7 +152,7 @@ class Gitlab:
     }
     LIB_SUPPORT: dict[str, dict[str, str]] = {  # noqa: RUF012
         'linux': {
-            'x86_64' : '4f2b923a164f8f8b77494df943ea52a3f7050716f9b9cbac9190f7460ca822fb',
+            'x86_64' : '54753d19e73bd8e1e671b576bb70c2adc56237c07ac60215f5478b5f0d369017',
             'aarch64': '104fe49eeb75ee91cb237acd251533aae98fb48c7e4e16517be6c0f4ccf677da'
         },
         'darwin': {


### PR DESCRIPTION
Delay upgrade to OpenCascade 8.x.x until upstream support is more mature.