### PR TITLE
CI/CD: gitleaks/pre-commit hooks

### DIFF
--- a/.docker/python_3.10.20-trixie/dockerfile
+++ b/.docker/python_3.10.20-trixie/dockerfile
@@ -1,5 +1,5 @@
 # Load the base image
-FROM python:3.10.19-slim-trixie
+FROM python:3.10.20-slim-trixie
 
 # Numerics research group
 LABEL maintainer="numerics@iag.uni-stuttgart.de"
@@ -18,6 +18,7 @@ RUN apt-get update              && \
     apt-get install -y --no-install-recommends \
       curl                         \
       git                          \
+      git-lfs                      \
       libglu1-mesa                 \
       libglut3.12                  \
       libgomp1                     \

--- a/.docker/python_3.11.15-trixie/dockerfile
+++ b/.docker/python_3.11.15-trixie/dockerfile
@@ -1,5 +1,5 @@
 # Load the base image
-FROM python:3.14.3-slim-trixie
+FROM python:3.11.15-slim-trixie
 
 # Numerics research group
 LABEL maintainer="numerics@iag.uni-stuttgart.de"
@@ -14,10 +14,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
 ARG ARCH
 
 # Setup required packages
-RUN apt-get update && \
+RUN apt-get update              && \
     apt-get install -y --no-install-recommends \
       curl                         \
       git                          \
+      git-lfs                      \
       libglu1-mesa                 \
       libglut3.12                  \
       libgomp1                     \
@@ -34,8 +35,8 @@ RUN apt-get update && \
       /tmp/*
 
 # Setup uv package manager
-RUN mkdir -p /.local/bin && \
+RUN mkdir -p /.local/bin        && \
     curl -fsSL -o /tmp/uv.tar.gz   \
-      https://github.com/astral-sh/uv/releases/download/0.10.2/uv-x86_64-unknown-linux-gnu.tar.gz && \
+      https://github.com/astral-sh/uv/releases/download/0.9.9/uv-x86_64-unknown-linux-gnu.tar.gz && \
     tar -xzf /tmp/uv.tar.gz -C /.local/bin --strip-components=1 && \
     rm /tmp/uv.tar.gz

--- a/.docker/python_3.12.13-trixie/dockerfile
+++ b/.docker/python_3.12.13-trixie/dockerfile
@@ -1,5 +1,5 @@
 # Load the base image
-FROM python:3.12.12-slim-trixie
+FROM python:3.12.13-slim-trixie
 
 # Numerics research group
 LABEL maintainer="numerics@iag.uni-stuttgart.de"
@@ -18,6 +18,7 @@ RUN apt-get update              && \
     apt-get install -y --no-install-recommends \
       curl                         \
       git                          \
+      git-lfs                      \
       libglu1-mesa                 \
       libglut3.12                  \
       libgomp1                     \

--- a/.docker/python_3.13.13-trixie/dockerfile
+++ b/.docker/python_3.13.13-trixie/dockerfile
@@ -1,5 +1,5 @@
 # Load the base image
-FROM python:3.11.14-slim-trixie
+FROM python:3.13.13-slim-trixie
 
 # Numerics research group
 LABEL maintainer="numerics@iag.uni-stuttgart.de"
@@ -18,6 +18,7 @@ RUN apt-get update              && \
     apt-get install -y --no-install-recommends \
       curl                         \
       git                          \
+      git-lfs                      \
       libglu1-mesa                 \
       libglut3.12                  \
       libgomp1                     \
@@ -36,6 +37,6 @@ RUN apt-get update              && \
 # Setup uv package manager
 RUN mkdir -p /.local/bin        && \
     curl -fsSL -o /tmp/uv.tar.gz   \
-      https://github.com/astral-sh/uv/releases/download/0.9.9/uv-x86_64-unknown-linux-gnu.tar.gz && \
+      https://github.com/astral-sh/uv/releases/download/0.10.2/uv-x86_64-unknown-linux-gnu.tar.gz && \
     tar -xzf /tmp/uv.tar.gz -C /.local/bin --strip-components=1 && \
     rm /tmp/uv.tar.gz

--- a/.docker/python_3.14.5-alpine3.23/dockerfile
+++ b/.docker/python_3.14.5-alpine3.23/dockerfile
@@ -1,5 +1,5 @@
 # Load the base image
-FROM python:3.14.3-alpine3.23
+FROM python:3.14.5-alpine3.23
 
 # Numerics research group
 LABEL maintainer="numerics@iag.uni-stuttgart.de"
@@ -19,6 +19,7 @@ RUN apk update && \
       fontconfig                   \
       gcompat                      \
       git                          \
+      git-lfs                      \
       glu                          \
       libstdc++                    \
       libgcc                       \

--- a/.docker/python_3.14.5-trixie/dockerfile
+++ b/.docker/python_3.14.5-trixie/dockerfile
@@ -1,5 +1,5 @@
 # Load the base image
-FROM python:3.13.12-slim-trixie
+FROM python:3.14.5-slim-trixie
 
 # Numerics research group
 LABEL maintainer="numerics@iag.uni-stuttgart.de"
@@ -14,10 +14,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
 ARG ARCH
 
 # Setup required packages
-RUN apt-get update              && \
+RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       curl                         \
       git                          \
+      git-lfs                      \
       libglu1-mesa                 \
       libglut3.12                  \
       libgomp1                     \
@@ -34,7 +35,7 @@ RUN apt-get update              && \
       /tmp/*
 
 # Setup uv package manager
-RUN mkdir -p /.local/bin        && \
+RUN mkdir -p /.local/bin && \
     curl -fsSL -o /tmp/uv.tar.gz   \
       https://github.com/astral-sh/uv/releases/download/0.10.2/uv-x86_64-unknown-linux-gnu.tar.gz && \
     tar -xzf /tmp/uv.tar.gz -C /.local/bin --strip-components=1 && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           source .venv/bin/activate
           uv pip install ruff
           ruff --version
-          ruff check --target-version=py310 --extend-ignore=E201,E202,E203,E221,E222,E225,E231,E271,E272 --line-length=132 --preview pyhope
+          ruff check --config pyproject.toml --preview
 
   ty:
     name: Lint / ty
@@ -116,7 +116,7 @@ jobs:
           source .venv/bin/activate
           uv pip install vulture
           vulture --version
-          vulture .gmsh pyhope
+          vulture --config pyproject.toml .gmsh pyhope
 
   gitleaks:
     name: Lint / gitleaks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     name: Lint / ruff
     runs-on: ubuntu-latest
     container:
-      image: python:3.14.3-slim-trixie
+      image: python:3.14.5-slim-trixie
     steps:
       - uses: actions/checkout@v6
         # with:
@@ -78,7 +78,7 @@ jobs:
     name: Lint / ty
     runs-on: ubuntu-latest
     container:
-      image: python:3.14.3-slim-trixie
+      image: python:3.14.5-slim-trixie
     steps:
       # Git LFS requires git
       - name: Install Git LFS
@@ -102,7 +102,7 @@ jobs:
     name: Lint / vulture
     runs-on: ubuntu-latest
     container:
-      image: python:3.14.3-slim-trixie
+      image: python:3.14.5-slim-trixie
     steps:
       - uses: actions/checkout@v6
         # with:
@@ -118,22 +118,47 @@ jobs:
           vulture --version
           vulture .gmsh pyhope
 
+  gitleaks:
+    name: Lint / gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: gitleaks
+
+  pre-commit:
+    name: Lint / pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: check-merge-conflict
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: check-symlinks
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: trailing-whitespace
+
+
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 # Compatibility
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
   compatibility:
     name: Compatibility / Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
-    needs: [ruff, ty, vulture]
+    needs: [ruff, ty, vulture, gitleaks, pre-commit]
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { python-version: "3.10", image: "python:3.10.19-slim-trixie" }
-          - { python-version: "3.11", image: "python:3.11.14-slim-trixie" }
-          - { python-version: "3.12", image: "python:3.12.12-slim-trixie" }
-          - { python-version: "3.13", image: "python:3.13.12-slim-trixie" }
-          - { python-version: "3.14", image: "python:3.14.3-slim-trixie"  }
+          - { python-version: "3.10", image: "python:3.10.20-slim-trixie" }
+          - { python-version: "3.11", image: "python:3.11.15-slim-trixie" }
+          - { python-version: "3.12", image: "python:3.12.13-slim-trixie" }
+          - { python-version: "3.13", image: "python:3.13.13-slim-trixie" }
+          - { python-version: "3.14", image: "python:3.14.5-slim-trixie"  }
     container:
       image: ${{ matrix.image }}
     steps:
@@ -165,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [compatibility]
     container:
-      image: python:3.14.3-slim-trixie
+      image: python:3.14.5-slim-trixie
     steps:
       # Git LFS requires git
       - name: Install Git LFS
@@ -239,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [compatibility]
     container:
-      image: python:3.14.3-slim-trixie
+      image: python:3.14.5-slim-trixie
     steps:
       # Git LFS requires git
       - name: Install Git LFS
@@ -326,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [examples, healthcheck]
     container:
-      image: python:3.14.3-slim-trixie
+      image: python:3.14.5-slim-trixie
     steps:
       - uses: actions/checkout@v6
         # with:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,7 +124,7 @@ ruff:
   script:
     - uv pip install ruff
     - ruff --version
-    - ruff check --target-version=py310 --extend-ignore=E201,E202,E203,E221,E222,E225,E231,E271,E272 --line-length=132 --preview pyhope
+    - ruff check --config pyproject.toml --preview
 
 ty:
   extends: .defaults
@@ -141,7 +141,7 @@ vulture:
   script:
     - uv pip install vulture
     - vulture --version
-    - vulture .gmsh pyhope
+    - vulture --config pyproject.toml .gmsh pyhope
 
 gitleaks:
   extends: .defaults

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,8 +24,8 @@
 
 # Official language image. Look for the different tagged releases at:
 # > https://hub.docker.com/r/library/python/tags/
-# image: ${CI_REGISTRY_NAME}/nrg-python:3.14.3-trixie-x86_64
-image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.14.3-trixie-x86_64
+# image: ${CI_REGISTRY_NAME}/nrg-python:3.14.5-trixie-x86_64
+image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.14.5-trixie-x86_64
 
 # Change pip's cache directory to be inside the project directory since we can only cache local items.
 variables:
@@ -143,6 +143,30 @@ vulture:
     - vulture --version
     - vulture .gmsh pyhope
 
+gitleaks:
+  extends: .defaults
+  stage: lint
+  before_script: *minimal-before-script
+  script:
+    - uv pip install pre-commit
+    - pre-commit --version
+    # detect hardcoded secrets
+    - pre-commit run gitleaks
+
+pre-commit:
+  extends: .defaults
+  stage: lint
+  before_script: *minimal-before-script
+  script:
+    - uv pip install pre-commit
+    - pre-commit --version
+    # check for merge conflicts
+    - pre-commit run check-merge-conflict
+    # check for broken symlinks
+    - pre-commit run check-symlinks
+    # trim trailing whitespace
+    - pre-commit run trailing-whitespace
+
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 # Compatibility
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -159,25 +183,25 @@ vulture:
 python:3.10:
   extends: .defaults
   stage: compatibility
-  image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.10.19-trixie-x86_64
+  image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.10.20-trixie-x86_64
   <<: *compatibility-script
 # Python 3.11 ----------------------------------------------------------------------------------------------------------------------------------------
 python:3.11:
   extends: .defaults
   stage: compatibility
-  image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.11.14-trixie-x86_64
+  image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.11.15-trixie-x86_64
   <<: *compatibility-script
 # Python 3.12 ----------------------------------------------------------------------------------------------------------------------------------------
 python:3.12:
   extends: .defaults
   stage: compatibility
-  image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.12.12-trixie-x86_64
+  image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.12.13-trixie-x86_64
   <<: *compatibility-script
 # Python 3.13 ----------------------------------------------------------------------------------------------------------------------------------------
 python:3.13:
   extends: .defaults
   stage: compatibility
-  image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.13.12-trixie-x86_64
+  image: registry.iag.uni-stuttgart.de/flexi/codes/pyhope/nrg-python:3.13.13-trixie-x86_64
   <<: *compatibility-script
 # Python 3.14 ----------------------------------------------------------------------------------------------------------------------------------------
 python:3.14:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,7 @@ repos:
     hooks:
       # Run the linter
       - id: ruff
-        name: ruff linter
-        alias: lint
+        name: ruff       [linter]
       # Run the formatter
       # - id: ruff-format
       #   name: ruff formatter
@@ -22,17 +21,35 @@ repos:
       # Run dead code detection
       # Paths are configured under [tool.vulture] in pyproject.toml
       - id: vulture
-        name: vulture dead code
-        alias: vulture
+        name: vulture    [dead code]
 
   # ty has no official pre-commit hook yet (https://github.com/astral-sh/ty/issues/269).
   # Run it as a local hook using the system-installed binary
   - repo: local
     hooks:
       - id: ty
-        name: ty type checker
-        alias: ty
+        name: ty         [type checker]
         entry: ty check --color always --project pyhope pyhope
         language: system
         pass_filenames: false
         types: [python]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      # Run secrets detection engine
+      - id: gitleaks
+        name: gitleaks   [detect hardcoded secrets]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      # Check for files that contain merge conflict strings
+      - id: check-merge-conflict
+        name: pre-commit [check for merge conflicts]
+      - id: check-symlinks
+        name: pre-commit [check for broken symlinks]
+      - id: trailing-whitespace
+        name: pre-commit [trim trailing whitespace]
+        exclude: \.(msh|patch)$
+        exclude_types: [markdown]


### PR DESCRIPTION
Add additional pre-commit checks for formatting and secret detection. Wire them up into the CI/CD to ensure tests run even when `pre-commit` is not installed locally.