### PR TITLE
CI/CD: Run pre-commit with --all-files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pre-commit/action@v3.0.1
         with:
-          extra_args: gitleaks
+          extra_args: --all-files gitleaks
 
   pre-commit:
     name: Lint / pre-commit
@@ -134,13 +134,13 @@ jobs:
       - uses: actions/checkout@v7
       - uses: pre-commit/action@v3.0.1
         with:
-          extra_args: check-merge-conflict
+          extra_args: --all-files check-merge-conflict
       - uses: pre-commit/action@v3.0.1
         with:
-          extra_args: check-symlinks
+          extra_args: --all-files check-symlinks
       - uses: pre-commit/action@v3.0.1
         with:
-          extra_args: trailing-whitespace
+          extra_args: --all-files trailing-whitespace
 
 
 # ----------------------------------------------------------------------------------------------------------------------------------------------------

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -151,7 +151,7 @@ gitleaks:
     - uv pip install pre-commit
     - pre-commit --version
     # detect hardcoded secrets
-    - pre-commit run gitleaks
+    - pre-commit run --all-files gitleaks
 
 pre-commit:
   extends: .defaults
@@ -161,11 +161,11 @@ pre-commit:
     - uv pip install pre-commit
     - pre-commit --version
     # check for merge conflicts
-    - pre-commit run check-merge-conflict
+    - pre-commit run --all-files check-merge-conflict
     # check for broken symlinks
-    - pre-commit run check-symlinks
+    - pre-commit run --all-files check-symlinks
     # trim trailing whitespace
-    - pre-commit run trailing-whitespace
+    - pre-commit run --all-files trailing-whitespace
 
 # ----------------------------------------------------------------------------------------------------------------------------------------------------
 # Compatibility


### PR DESCRIPTION
In the default configuration, `pre-commit` only checks currently staged files. Add `--all-files` to check all files