### PR TITLE
Checks: Perform normal calculation using full integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ $ pyhope tutorials/1-01-cartbox/parameter.ini
 │ INIT OUTPUT...
 │                     ProjectName │ 1-01-cartbox                    │ *CUSTOM │
 │                    OutputFormat │ 0 [HDF5]                        │ *CUSTOM │
+│                     OutputBytes │ 0 [int32]                       │ DEFAULT │
 │                       DebugMesh │ T                               │ *CUSTOM │
 │                       DebugVisu │ F                               │ *CUSTOM │
 ├─────────────────────────────────────────────
@@ -122,23 +123,26 @@ $ pyhope tutorials/1-01-cartbox/parameter.ini
 ├── BUILD DATA STRUCTURE...
 ├────
 ├── Removing duplicate points
-├── Ensuring normals point outward
-├────
-│             CheckSurfaceNormals │ True                            │ DEFAULT │
-│             Processing Elements |█████████████████████████████████| 512/512 [100%] in 0.0s (24000.00/s)
 ├────
 ├── Generating sides
 ├─────────────────────────────────────────────
 │ SORT MESH...
 ├────
 │                     MeshSorting │ 1 [SFC]                         │ DEFAULT │
+│                  MeshSortingSFC │ 0 [default]                     │ DEFAULT │
 ├────
 ├── Sorting elements along space-filling curve
+├─────────────────────────────────────────────
+│ CHECK NORMALS POINTING OUTWARDS...
+├────
+│             CheckSurfaceNormals │ True                            │ DEFAULT │
+│             Processing Elements |█████████████████████████████████| 512/512 [100%] in 0.1s (2559.71/s) 
 ├─────────────────────────────────────────────
 │ CONNECT MESH...
 ├────
 │               doPeriodicCorrect │ False                           │ DEFAULT │
 │                       doMortars │ True                            │ DEFAULT │
+│                 doMortarRebuild │ 1 [auto]                        │ DEFAULT │
 │                Processing Sides |█████████████████████████████████| 3072/3072 [100%] in 0.0s (24000.00/s)
 ├────
 │  Number of sides                :         3072

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ $ pyhope tutorials/1-01-cartbox/parameter.ini
 │ CHECK NORMALS POINTING OUTWARDS...
 ├────
 │             CheckSurfaceNormals │ True                            │ DEFAULT │
-│             Processing Elements |█████████████████████████████████| 512/512 [100%] in 0.1s (2559.71/s) 
+│             Processing Elements |█████████████████████████████████| 512/512 [100%] in 0.0s (24000.00/s)
 ├─────────────────────────────────────────────
 │ CONNECT MESH...
 ├────
@@ -210,8 +210,8 @@ This is a scientific project. If you use PyHOPE for publications or presentation
   author       = {Kopper, Patrick and Blind, Marcel P. and Schwarz, Anna and Kurz, Marius and Rodach, Felix and Copplestone, Stephen M. and Beck, Andrea D.},
   journal      = {Journal of Open Source Software},
   year         = {2025},
-  volume       = {10}, 
-  number       = {115}, 
+  volume       = {10},
+  number       = {115},
   pages        = {8769},
   publisher    = {The Open Journal},
   doi          = {10.21105/joss.08769}

--- a/pyhope/basis/basis_orient.py
+++ b/pyhope/basis/basis_orient.py
@@ -30,6 +30,7 @@ import gc
 import re
 import sys
 from typing import Final, Optional
+from collections.abc import Callable
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -47,35 +48,66 @@ import pyhope.mesh.mesh_vars as mesh_vars
 from pyhope.common.common_numba import jit, types
 from pyhope.mesh.mesh_common import LINMAP
 from pyhope.mesh.mesh_common import dir_to_nodes, faces
+from pyhope.basis.basis_basis import change_basis_2D
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Local definitions
 # ----------------------------------------------------------------------------------------------------------------------------------
 # ==================================================================================================================================
 
 
-@jit((types.float64)(types.float64[:, :, ::1], types.float64[::1]), nopython=True, cache=True, nogil=True)
-def eval_dotprod(fpoints: npt.NDArray[np.float64], nVecFace: npt.NDArray[np.float64]) -> np.float64:
-    # nVecFace = nVecFace / np.linalg.norm(nVecFace)
-    # > Manually compute norm
-    nVecFace = nVecFace / np.sqrt(nVecFace[0]*nVecFace[0] + nVecFace[1]*nVecFace[1] + nVecFace[2]*nVecFace[2])
-
-    vec1 = fpoints[-1, 0, :] - fpoints[0, 0, :]
-    vec2 = fpoints[0, -1, :] - fpoints[0, 0, :]
-
-    # normal = np.cross(vec1, vec2)
-    # > Manually compute cross product
-    normal = np.empty_like(vec1)
-    normal[0] = vec1[1] * vec2[2] - vec1[2] * vec2[1]
-    normal[1] = vec1[2] * vec2[0] - vec1[0] * vec2[2]
-    normal[2] = vec1[0] * vec2[1] - vec1[1] * vec2[0]
-
-    # Dot product and check if normal points outwards
-    # > Manually compute dot product
-    return nVecFace[0]*normal[0] + nVecFace[1]*normal[1] + nVecFace[2]*normal[2]
+def init_worker(function : Callable,
+                VdmEqToGP: npt.NDArray[np.float64],
+                DGP      : npt.NDArray[np.float64],
+                weights  : npt.NDArray[np.float64]) -> None:
+    """Initializer to set process-local attributes on the worker function
+    """
+    function.VdmEqToGP = VdmEqToGP
+    function.DGP       = DGP
+    function.weights   = weights
 
 
-def check_orientation(ionodes : npt.NDArray,
-                      elemType: int,
+@jit(types.Tuple((types.float64, types.float64, types.float64))(
+    types.float64[:, :, ::1],
+    types.float64[:, :, ::1],
+    types.float64[:,    ::1]
+), nopython=True, cache=True, nogil=True)
+def eval_dotprod(dXdetaGP: npt.NDArray[np.float64],
+                 dXdxiGP:  npt.NDArray[np.float64],
+                 weights:  npt.NDArray[np.float64]) -> tuple[npt.NDArray[np.float64], ...]:
+    NSurf0 = -np.sum(weights * (dXdxiGP[1] * dXdetaGP[2] - dXdxiGP[2] * dXdetaGP[1]))
+    NSurf1 = -np.sum(weights * (dXdxiGP[2] * dXdetaGP[0] - dXdxiGP[0] * dXdetaGP[2]))
+    NSurf2 = -np.sum(weights * (dXdxiGP[0] * dXdetaGP[1] - dXdxiGP[1] * dXdetaGP[0]))
+    return NSurf0, NSurf1, NSurf2
+
+
+def eval_nsurf(XGeo:    npt.NDArray[np.float64],
+               Vdm:     npt.NDArray[np.float64],
+               DGP:     npt.NDArray[np.float64],
+               weights: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """ Evaluate the surface integral for normals over a side of an element
+    """
+    # Change basis to Gauss points
+    xGP      = change_basis_2D(Vdm, XGeo)
+
+    # Compute derivatives at all Gauss points
+    dXdxiGP  = np.empty_like(xGP)
+    dXdetaGP = np.empty_like(xGP)
+    DT       = DGP.T
+    for k in range(3):
+        dXdxiGP[ k] = DGP @ xGP[k]
+        dXdetaGP[k] = xGP[k] @ DT
+
+    # Compute the weighted cross product integral
+    NSurf0, NSurf1, NSurf2 = eval_dotprod(dXdetaGP, dXdxiGP, weights)
+
+    return np.array((NSurf0, NSurf1, NSurf2), dtype=xGP.dtype)
+
+
+def check_orientation(ionodes  : npt.NDArray,
+                      elemType : int,
+                      VdmEqToGP: npt.NDArray[np.float64],
+                      DGP      : npt.NDArray[np.float64],
+                      weights  : npt.NDArray[np.float64],
                      ) -> tuple[bool, Optional[str]]:
     """ Check the orientation of the surface normals
     """
@@ -91,19 +123,18 @@ def check_orientation(ionodes : npt.NDArray,
     sface    = None
 
     for face in faces(elemType):
-        # Center of face
         indices, doTransp = dir_to_nodes(face, elemType, mesh_vars.nGeo)
         fnodes  = mapnodes[indices] if not doTransp else mapnodes[indices].transpose()
         fpoints = iopoints[fnodes]
 
-        # Tangent and normal vectors
-        nVecFace = cElem - fpoints.reshape(-1, 3).mean(axis=0)
-        # nVecFace = nVecFace / np.linalg.norm(nVecFace)
-        # nVecFace = nVecFace / np.sqrt(np.dot(nVecFace, nVecFace))
-        # > Manually compute dot product
-        dotprod = eval_dotprod(fpoints, nVecFace)
+        # Calculate high-order surface normal vector via Gauss integration
+        nSurf = eval_nsurf(fpoints.transpose(2, 0, 1), VdmEqToGP, DGP, weights)
 
-        if dotprod < 0.:
+        # Vector pointing from face center to element center
+        fCenter  = fpoints.reshape(-1, 3).mean(axis=0)
+        vCenter  = cElem - fCenter
+
+        if np.dot(nSurf, vCenter) > 0.:
             success = False
             sface   = face
             break
@@ -117,16 +148,21 @@ def process_chunk(chunk: tuple) -> list:
     chunk_results = []
     for elemChunk in chunk:
         iElem, ionodes, elemType = elemChunk
-        elem_result = check_orientation(ionodes, elemType)
+        elem_result = check_orientation(ionodes, elemType,
+                                        process_chunk.VdmEqToGP,  # ty: ignore[unresolved-attribute]
+                                        process_chunk.DGP,        # ty: ignore[unresolved-attribute]
+                                        process_chunk.weights)    # ty: ignore[unresolved-attribute]
         # Append a lightweight sentinel (None) for successes, actual failure list otherwise
         chunk_results.append((elem_result, iElem) if not elem_result[0] else None)
     return chunk_results
 
 
-def OrientMesh() -> None:
+def CheckOrient() -> None:
     # Local imports ----------------------------------------
     import pyhope.mesh.mesh_vars as mesh_vars
     import pyhope.output.output as hopout
+    from pyhope.basis.basis_basis import barycentric_weights, legendre_gauss_nodes
+    from pyhope.basis.basis_basis import calc_vandermonde, polynomial_derivative_matrix
     from pyhope.common.common_parallel import run_in_parallel
     from pyhope.common.common_vars import np_mtp
     from pyhope.readintools.readintools import GetLogical
@@ -140,6 +176,16 @@ def OrientMesh() -> None:
         return None
 
     mesh = mesh_vars.mesh
+    nGeo: Final[int] = mesh_vars.nGeo
+
+    # Setup mathematical structures identical to CheckWatertight
+    xEq:       Final[npt.NDArray[np.float64]] = np.linspace(-1., 1., nGeo+1)
+    wBaryEq:   Final[npt.NDArray[np.float64]] = barycentric_weights(nGeo+1, xEq)
+
+    xGP, wGP  = legendre_gauss_nodes(nGeo+1)
+    DGP:       Final[npt.NDArray[np.float64]] = polynomial_derivative_matrix(nGeo+1, xGP)
+    VdmEqToGP: Final[npt.NDArray[np.float64]] = calc_vandermonde(nGeo+1, nGeo+1, wBaryEq, xEq, xGP)
+    weights:   Final[npt.NDArray[np.float64]] = np.outer(wGP, wGP)
 
     elemNames: Final[dict] = mesh_vars.ELEMTYPE.name
     elemKeys : Final       = mesh_vars.ELEMTYPE.type.keys()
@@ -172,10 +218,12 @@ def OrientMesh() -> None:
             res   = run_in_parallel(process_chunk,                                                          # noqa: E251
                                     tasks,                                                                  # noqa: E251
                                     chunk_size = max(1, min(1000, max(10, int(len(tasks)/(40.*np_mtp))))),  # noqa: E251
+                                    initializer = init_worker,                                              # noqa: E251
+                                    init_args   = (process_chunk, VdmEqToGP, DGP, weights),                 # noqa: E251
                                     ordering   = False,                                                     # noqa: E251
                                    )
         else:
-            res   = np.fromiter(((check_orientation(ioelems[iElem - nElems], elemType), iElem)
+            res   = np.fromiter(((check_orientation(ioelems[iElem - nElems], elemType, VdmEqToGP, DGP, weights), iElem)
                                   for iElem in range(nElems, nElems + nIOElems)), dtype=object)
 
         if len(res) > 0 and not np.all([success for (success, _), _ in res]):

--- a/pyhope/basis/basis_orient.py
+++ b/pyhope/basis/basis_orient.py
@@ -30,7 +30,6 @@ import gc
 import re
 import sys
 from typing import Final, Optional
-from collections.abc import Callable
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -45,62 +44,13 @@ if typing.TYPE_CHECKING:
 # Local imports
 # ----------------------------------------------------------------------------------------------------------------------------------
 import pyhope.mesh.mesh_vars as mesh_vars
-from pyhope.common.common_numba import jit, types
+from pyhope.basis.basis_watertight import eval_nsurf
 from pyhope.mesh.mesh_common import LINMAP
 from pyhope.mesh.mesh_common import dir_to_nodes, faces
-from pyhope.basis.basis_basis import change_basis_2D
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Local definitions
 # ----------------------------------------------------------------------------------------------------------------------------------
 # ==================================================================================================================================
-
-
-def init_worker(function : Callable,
-                VdmEqToGP: npt.NDArray[np.float64],
-                DGP      : npt.NDArray[np.float64],
-                weights  : npt.NDArray[np.float64]) -> None:
-    """Initializer to set process-local attributes on the worker function
-    """
-    function.VdmEqToGP = VdmEqToGP
-    function.DGP       = DGP
-    function.weights   = weights
-
-
-@jit(types.Tuple((types.float64, types.float64, types.float64))(
-    types.float64[:, :, ::1],
-    types.float64[:, :, ::1],
-    types.float64[:,    ::1]
-), nopython=True, cache=True, nogil=True)
-def eval_dotprod(dXdetaGP: npt.NDArray[np.float64],
-                 dXdxiGP:  npt.NDArray[np.float64],
-                 weights:  npt.NDArray[np.float64]) -> tuple[npt.NDArray[np.float64], ...]:
-    NSurf0 = -np.sum(weights * (dXdxiGP[1] * dXdetaGP[2] - dXdxiGP[2] * dXdetaGP[1]))
-    NSurf1 = -np.sum(weights * (dXdxiGP[2] * dXdetaGP[0] - dXdxiGP[0] * dXdetaGP[2]))
-    NSurf2 = -np.sum(weights * (dXdxiGP[0] * dXdetaGP[1] - dXdxiGP[1] * dXdetaGP[0]))
-    return NSurf0, NSurf1, NSurf2
-
-
-def eval_nsurf(XGeo:    npt.NDArray[np.float64],
-               Vdm:     npt.NDArray[np.float64],
-               DGP:     npt.NDArray[np.float64],
-               weights: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
-    """ Evaluate the surface integral for normals over a side of an element
-    """
-    # Change basis to Gauss points
-    xGP      = change_basis_2D(Vdm, XGeo)
-
-    # Compute derivatives at all Gauss points
-    dXdxiGP  = np.empty_like(xGP)
-    dXdetaGP = np.empty_like(xGP)
-    DT       = DGP.T
-    for k in range(3):
-        dXdxiGP[ k] = DGP @ xGP[k]
-        dXdetaGP[k] = xGP[k] @ DT
-
-    # Compute the weighted cross product integral
-    NSurf0, NSurf1, NSurf2 = eval_dotprod(dXdetaGP, dXdxiGP, weights)
-
-    return np.array((NSurf0, NSurf1, NSurf2), dtype=xGP.dtype)
 
 
 def check_orientation(ionodes  : npt.NDArray,
@@ -163,12 +113,14 @@ def CheckOrient() -> None:
     import pyhope.output.output as hopout
     from pyhope.basis.basis_basis import barycentric_weights, legendre_gauss_nodes
     from pyhope.basis.basis_basis import calc_vandermonde, polynomial_derivative_matrix
+    from pyhope.basis.basis_watertight import init_worker
     from pyhope.common.common_parallel import run_in_parallel
     from pyhope.common.common_vars import np_mtp
     from pyhope.readintools.readintools import GetLogical
     # ------------------------------------------------------
 
-    hopout.routine('Ensuring normals point outward')
+    hopout.separator()
+    hopout.info('CHECK NORMALS POINTING OUTWARDS...')
     hopout.sep()
 
     checkSurfaceNormals = GetLogical('CheckSurfaceNormals')

--- a/pyhope/basis/basis_watertight.py
+++ b/pyhope/basis/basis_watertight.py
@@ -96,7 +96,7 @@ def eval_nsurf(XGeo:    npt.NDArray[np.float64],
     # # dXdetaGP = np.moveaxis(dXdetaGP, 0, 1).reshape(3, -1)              # Flatten for cross computation (slower)
     # dXdetaGP = dXdetaGP.reshape(3, -1)                                 # Flatten for cross computation
 
-    # Compute derivatives at all Gauss points using matrix multiplications to avoid extra copies
+    # Compute derivatives at all Gauss points
     dXdxiGP  = np.empty_like(xGP)
     dXdetaGP = np.empty_like(xGP)
     DT       = DGP.T
@@ -120,7 +120,7 @@ def eval_nsurf(XGeo:    npt.NDArray[np.float64],
     # Integrate over the Gauss points
     # return -np.sum(nVecW, axis=(1, 2))              # Sum over the last two axes
 
-    # Compute the weighted cross product integral directly
+    # Compute the weighted cross product integral
     NSurf0, NSurf1, NSurf2 = eval_dotprod(dXdetaGP, dXdxiGP, weights)
 
     return np.array((NSurf0, NSurf1, NSurf2), dtype=xGP.dtype)
@@ -243,9 +243,9 @@ def process_chunk(chunk: tuple) -> list:
     chunk_results = []
     for elem in chunk:
         elem_result = check_sides(elem,
-                                   process_chunk.VdmEqToGP,  # pyright: ignore[reportFunctionMemberAccess] # ty: ignore[unresolved-attribute]
-                                   process_chunk.DGP,        # pyright: ignore[reportFunctionMemberAccess] # ty: ignore[unresolved-attribute]
-                                   process_chunk.weights,    # pyright: ignore[reportFunctionMemberAccess] # ty: ignore[unresolved-attribute]
+                                   process_chunk.VdmEqToGP,  # ty: ignore[unresolved-attribute]
+                                   process_chunk.DGP,        # ty: ignore[unresolved-attribute]
+                                   process_chunk.weights,    # ty: ignore[unresolved-attribute]
                                    failed_only=True)
         # Append a lightweight sentinel (None) for successes, actual failure list otherwise
         chunk_results.append(elem_result)

--- a/pyhope/io/io_debug.py
+++ b/pyhope/io/io_debug.py
@@ -64,6 +64,8 @@ meshio.xdmf.main.XdmfWriter.__init__ = XdmfWriterInit  # pyright: ignore[reportA
 #
 #     tree = ET.ElementTree(vtkfile)
 #     tree.write(filename, encoding='utf-8', xml_declaration=True)
+
+
 @cache
 def isValidInt(s: Any) -> bool:  # noqa: ANN401
     try:

--- a/pyhope/io/io_debug.py
+++ b/pyhope/io/io_debug.py
@@ -25,8 +25,10 @@
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Standard libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
+from collections import defaultdict
 from functools import cache
-from typing import Any, Final, cast
+from typing import Any, Final, Optional
+from typing import cast
 # ----------------------------------------------------------------------------------------------------------------------------------
 # Third-party libraries
 # ----------------------------------------------------------------------------------------------------------------------------------
@@ -76,20 +78,163 @@ def isValidInt(s: Any) -> bool:  # noqa: ANN401
         return True
 
 
+def FillElemData(melems: list,
+                 elems : dict,
+                 hasIJK: bool,
+                 # hasFEM: bool,
+                 types : list,
+                 tInv  : dict[str, int],
+                 pMap  : npt.NDArray,
+                ) -> tuple[dict, dict[str, list]]:
+    # Local imports ----------------------------------------
+    from pyhope.mesh.mesh_vars import ELEMTYPE
+    # ------------------------------------------------------
+
+    # Instantiate ELEMTYPE
+    elemTypeClass = ELEMTYPE()
+
+    # Create a defaultdict since we have optional members
+    elemdata = defaultdict(lambda: [[] for _ in range(len(types))])
+
+    # Populate connectivity and data
+    for melem in melems:
+        # Correct ElemType for NGeo = 1
+        elemNum  = melem.type % 10
+        elemType = elemTypeClass.inam[elemNum + 100]
+        elemType = ''.join(elemType) if isinstance(elemType, list) else elemType
+        elemZone = int(melem.zone) if (melem.zone is not None and isValidInt(melem.zone)) else 1
+        tidx     = tInv[elemType]
+
+        # pMap is already sorted
+        elemNodes = np.searchsorted(pMap, cast(np.ndarray, melem.nodes)[:elemNum])
+        elems[elemType].append(elemNodes)
+
+        # Add the elemData
+        elemdata['ElemID'  ][tidx].append(melem.elemID + 1)
+        elemdata['ElemType'][tidx].append(melem.type)
+        elemdata['ElemZone'][tidx].append(elemZone)
+        if 'ElemJacobian' in elemdata:
+            elemdata['ElemJacobian'][tidx].append(melem.jacobian)
+        if hasIJK:
+            elemdata['Elem_I'      ][tidx].append(cast(np.ndarray, melem.elemIJK)[0])
+            elemdata['Elem_J'      ][tidx].append(cast(np.ndarray, melem.elemIJK)[1])
+            elemdata['Elem_K'      ][tidx].append(cast(np.ndarray, melem.elemIJK)[2])
+
+    return elems, dict(elemdata)
+
+
+def FillSideData(msides: list,
+                 sides : dict,
+                 sypes : list,
+                 sInv  : dict[str, int],
+                 pMap  : npt.NDArray,
+                 bcs   : list,
+                ) -> tuple[dict, dict[str, list]]:
+
+    # Create a defaultdict since we have optional members
+    sidedata = defaultdict(lambda: [[] for _ in range(len(sypes))])
+
+    # Populate connectivity and data
+    for side in tuple(s for s in msides if s.bcid is not None):
+        sideType = 'triangle' if side.sideType == 3 else 'quad'
+        sidx     = sInv[sideType]
+
+        # Add the side
+        sideNodes = np.searchsorted(pMap, np.asarray(side.corners))
+        sides[sideType].append(sideNodes)
+
+        # Add the sideData
+        bcID = side.bcid
+        bc   = bcs[bcID]
+        sidedata['ElemID'  ][sidx].append(side.elemID + 1)
+        sidedata['BCID'    ][sidx].append(bcID        + 1)
+        sidedata['BCType'  ][sidx].append(bc.type[0]      )
+        sidedata['BCState' ][sidx].append(bc.type[2]      )
+        sidedata['BCAlpha' ][sidx].append(bc.type[3]      )
+
+    return sides, dict(sidedata)
+
+
+def FillEdgeData(melems: list,
+                 edges : dict,
+                 hasFEM: bool,
+                 pMap  : npt.NDArray,
+                ) -> tuple[Optional[dict], Optional[dict[str, list]]]:
+    # Local imports ----------------------------------------
+    from pyhope.mesh.mesh_common import edges as ELEMEDGES
+    from pyhope.mesh.mesh_vars import ELEMTYPE
+    # ------------------------------------------------------
+
+    if not hasFEM:
+        return edges, None
+
+    # Instantiate ELEMTYPE
+    elemTypeClass = ELEMTYPE()
+
+    # Create a defaultdict since we have optional members
+    edgedata = defaultdict(list)
+
+    # Populate connectivity and data
+    for melem in melems:
+        # Correct ElemType for NGeo = 1
+        elemNum  = melem.type % 10
+        elemType = elemTypeClass.inam[elemNum + 100]
+        elemType = ''.join(elemType) if isinstance(elemType, list) else elemType
+
+        # Create the FEM edges
+        elemEdges = ELEMEDGES(elemType)
+        for edge in elemEdges:
+            # Add the edge
+            edgeInfo  = cast(dict, melem.edgeInfo)[edge]
+            edgeNodes = np.searchsorted(pMap, np.asarray(edgeInfo[3]))
+            edges['line'].append(edgeNodes)
+
+            edgedata['FEMEdgeID'  ].append(edgeInfo[1])
+            edgedata['LocEdge'    ].append(edgeInfo[0])
+
+    return edges, dict(edgedata)
+
+
+def FillNodeData(melems: list,
+                 nodes : dict,
+                 hasFEM: bool,
+                 pMap  : npt.NDArray,
+                ) -> tuple[Optional[dict], Optional[dict[str, list]]]:
+
+    if not hasFEM:
+        return nodes, None
+
+    # Fully create the nodes here
+    nodes = cast(dict[str, npt.ArrayLike], {'vertex': [np.asarray([s])  for s in range(len(pMap))]})  # noqa: E272
+    # Create a defaultdict since we have optional members
+    nodedata = defaultdict(lambda: [1 for _ in range(len(pMap))])
+
+    # Populate connectivity and data
+    for melem in melems:
+        # Correct ElemType for NGeo = 1
+        elemNum  = melem.type % 10
+        # pMap is already sorted
+        elemNodes = np.searchsorted(pMap, cast(np.ndarray, melem.nodes)[:elemNum])
+
+        # Create the FEM vertices
+        for locNode, node in enumerate(elemNodes):
+            # Add the nodeData
+            nodedata['FEMVertexID'][node] = cast(dict, melem.vertexInfo)[locNode][0]
+
+    return nodes, dict(nodedata)
+
+
 def DebugIO() -> None:
     """ Routine to output the debug mesh. Downcast the existing
         PyHOPE format to first order, enrich with debug information
-        and output
+        and output in XDMF format
     """
     # Local imports ----------------------------------------
     import pyhope.io.io_vars as io_vars
     import pyhope.mesh.mesh_vars as mesh_vars
     import pyhope.output.output as hopout
-    from pyhope.mesh.mesh_common import edges as ELEMEDGES
     from pyhope.mesh.mesh_vars import ELEMTYPE
     # ------------------------------------------------------
-
-    # hopout.sep()
 
     mesh   : Final             = mesh_vars.mesh
     mpoints: Final[np.ndarray] = mesh.points
@@ -135,7 +280,6 @@ def DebugIO() -> None:
     # Create ordered mapping from first-order points to high-order points
     points = np.concatenate([np.asarray(melem.nodes)[:melem.type % 10] for melem in melems])
     pMap   = np.unique(points)
-    # pInv   = dict(zip(pMap, range(len(pMap))))
 
     hasIJK = bool(hasattr(mesh_vars, 'nElemsIJK')  and mesh_vars.nElemsIJK  is not None)  # noqa: E272
     hasFEM = bool(hasattr(melems[0], 'vertexInfo') and melems[0].vertexInfo is not None)
@@ -146,7 +290,6 @@ def DebugIO() -> None:
     for st in sidetypes:
         sides.setdefault(st, [])
     if hasFEM:
-        nodes.setdefault('vertex', [])
         edges.setdefault('line'  , [])
 
     # Create ordered mapping from first-order elems to high-order elems
@@ -154,98 +297,14 @@ def DebugIO() -> None:
     # Create ordered mapping from first-order sides to high-order sides
     sypes  = list(sidetypes)
 
-    elemdata: dict[str, list] = {'ElemID'  : [[] for _ in range(len(types))],
-                                 'ElemType': [[] for _ in range(len(types))],
-                                 'ElemZone': [[] for _ in range(len(types))],
-                                }
-    # (Optional:) Add Jacobians
-    if melems and (getattr(melems[0], 'jacobian', None) is not None):
-        elemdata.update({'ElemJacobian': [[] for _ in range(len(types))]})
-    # (Optional:) Add IJK sorting
-    if hasIJK:
-        elemdata.update({'Elem_I'      : [[] for _ in range(len(types))]})
-        elemdata.update({'Elem_J'      : [[] for _ in range(len(types))]})
-        elemdata.update({'Elem_K'      : [[] for _ in range(len(types))]})
-
-    sidedata: dict[str, list] = {'ElemID'  : [[] for _ in range(len(sypes))],
-                                 'BCID'    : [[] for _ in range(len(sypes))],
-                                 'BCType'  : [[] for _ in range(len(sypes))],
-                                 'BCState' : [[] for _ in range(len(sypes))],
-                                 'BCAlpha' : [[] for _ in range(len(sypes))],
-                                }
-
-    nodedata: dict[str, list] = {}
-    edgedata: dict[str, list] = {}
-    if hasFEM:
-        edgedata.update(                       {'FEMEdgeID'  : [],
-                                                'LocEdge'    : [],
-                                               })
-        # Fully create the nodes here
-        nodes = cast(dict[str, npt.ArrayLike], {'vertex':      [np.asarray([s])  for s in range(len(pMap))]})  # noqa: E272
-        nodedata.update(                       {'FEMVertexID': [-1 for _ in range(len(pMap))],
-                                               })
-
-    # Populate connectivity and data
-    for melem in melems:
-        # Correct ElemType for NGeo = 1
-        elemNum  = melem.type % 10
-        elemType = elemTypeClass.inam[elemNum + 100]
-        elemType = ''.join(elemType) if isinstance(elemType, list) else elemType
-        elemZone = int(melem.zone) if (melem.zone is not None and isValidInt(melem.zone)) else 1
-        tidx     = tInv[elemType]
-
-        # pMap is already sorted
-        elemNodes = np.searchsorted(pMap, cast(np.ndarray, melem.nodes)[:elemNum])
-        elems[elemType].append(elemNodes)
-
-        # Add the elemData
-        elemdata['ElemID'  ][tidx].append(melem.elemID + 1)
-        elemdata['ElemType'][tidx].append(melem.type)
-        elemdata['ElemZone'][tidx].append(elemZone)
-        if 'ElemJacobian' in elemdata:
-            elemdata['ElemJacobian'][tidx].append(melem.jacobian)
-        if hasIJK:
-            elemdata['Elem_I'      ][tidx].append(cast(np.ndarray, melem.elemIJK)[0])
-            elemdata['Elem_J'      ][tidx].append(cast(np.ndarray, melem.elemIJK)[1])
-            elemdata['Elem_K'      ][tidx].append(cast(np.ndarray, melem.elemIJK)[2])
-
-        # Add the side[Data]
-        for sideID in melem.sides:  # ty: ignore [not-iterable]
-            # Only consider boundary sides
-            side = msides[sideID]
-            if side.bcid is not None:
-                sideType = 'triangle' if side.sideType == 3 else 'quad'
-                sidx     = sInv[sideType]
-
-                # Add the side
-                sideNodes = np.searchsorted(pMap, np.asarray(side.corners))
-                sides[sideType].append(sideNodes)
-
-                # Add the sideData
-                bcID = side.bcid
-                bc   = bcs[bcID]
-                sidedata['ElemID'  ][sidx].append(melem.elemID + 1)
-                sidedata['BCID'    ][sidx].append(bcID         + 1)
-                sidedata['BCType'  ][sidx].append(bc.type[0]      )
-                sidedata['BCState' ][sidx].append(bc.type[2]      )
-                sidedata['BCAlpha' ][sidx].append(bc.type[3]      )
-
-        if hasFEM:
-            # Create the FEM vertices
-            for locNode, node in enumerate(elemNodes):
-                # Add the nodeData
-                nodedata['FEMVertexID'][node] = cast(dict, melem.vertexInfo)[locNode][0]  # pyright: ignore[reportPossiblyUnboundVariable]
-
-            # Create the FEM edges
-            elemEdges = ELEMEDGES(elemType)
-            for edge in elemEdges:
-                # Add the edge
-                edgeInfo  = cast(dict, melem.edgeInfo)[edge]
-                edgeNodes = np.searchsorted(pMap, np.asarray(edgeInfo[3]))
-                edges['line'].append(edgeNodes)
-
-                edgedata['FEMEdgeID'  ].append(edgeInfo[1])
-                edgedata['LocEdge'    ].append(edgeInfo[0])
+    # Fill elem data
+    elems, elemdata = FillElemData(melems, elems, hasIJK, types, tInv, pMap)
+    # Fill the side data (optional)
+    sides, sidedata = FillSideData(msides, sides,         sypes, sInv, pMap, bcs)
+    # Fill the edge data (optional)
+    edges, edgedata = FillEdgeData(melems, edges, hasFEM,              pMap)
+    # Fill the node data (optional)
+    nodes, nodedata = FillNodeData(melems, nodes, hasFEM,              pMap)
 
     # Update points to unique first-order coords
     coords = mpoints[pMap]
@@ -268,11 +327,6 @@ def DebugIO() -> None:
                              info      = eleminfo,   # noqa: E251
                             )
     debugOut.append(debugElem)
-    # fname = f'{pname}_Debug.xdmf'
-    # hopout.routine(f'Writing volume  debug mesh to "{fname}"')
-    # debugElem.write(fname)
-    # # Clean-up for memory safety
-    # del debugElem
 
     # Find the mapping from the side keys to the elemtypes
     sideOrder = [sInv[cb] for cb in sides]
@@ -290,14 +344,8 @@ def DebugIO() -> None:
                              info      = sideinfo,   # noqa: E251
                             )
     debugOut.append(debugSide)
-    # fname = f'{pname}_Debug.xdmf'
-    # hopout.routine(f'Writing surface debug mesh to "{fname}"')
-    # debugSide.write(fname)
-    # # Clean-up for memory safety
-    # del debugSide
-    # del fname
 
-    if hasFEM:
+    if edgedata is not None:
         # Ensure cell_data lists are aligned to the actual cell block order used by meshio.Mesh
         edgedata = {k: [np.asarray(v)] for k, v in edgedata.items()}
         edgeinfo = {'name': 'FEMEdges'}
@@ -308,13 +356,8 @@ def DebugIO() -> None:
                                  info      = edgeinfo,   # noqa: E251
                                 )
         debugOut.append(debugEdge)
-        # fname = f'{pname}_DebugEdge.vtu'
-        # hopout.routine(f'Writing edge    debug mesh to "{fname}"')
-        # debugNode.write(fname)
-        # # Clean-up for memory safety
-        # del debugEdge
-        # del fname
 
+    if nodedata is not None:
         # Ensure cell_data lists are aligned to the actual cell block order used by meshio.Mesh
         nodedata = {k: [np.asarray(v)] for k, v in nodedata.items()}
         nodeinfo = {'name': 'FEMVertices'}
@@ -325,20 +368,7 @@ def DebugIO() -> None:
                                  info      = nodeinfo,   # noqa: E251
                                 )
         debugOut.append(debugNode)
-        # fname = f'{pname}_DebugNode.vtu'
-        # hopout.routine(f'Writing vertex  debug mesh to "{fname}"')
-        # debugNode.write(fname)
-        # # Clean-up for memory safety
-        # del debugNode
-        # del fname
 
     fname = f'{pname}_DebugMesh.xdmf'
     hopout.routine(f'Writing XDMF mesh to "{fname}"')
     meshio.xdmf.main.XdmfWriter(fname, debugOut)
-
-    # (Optional:) Write wrapper for multiblock file
-    # blocks = [(0, 'VolumeMesh' , f'{pname}_DebugElem.vtu'),
-    #           (1, 'SurfaceMesh', f'{pname}_DebugSide.vtu')]
-    #
-    # writeVTM(f'{pname}_DebugMesh.vtm',
-    #          blocks)

--- a/pyhope/mesh/extrude/mesh_extrude.py
+++ b/pyhope/mesh/extrude/mesh_extrude.py
@@ -53,12 +53,14 @@ def MeshExtrude(mesh: meshio.Mesh) -> meshio.Mesh:
     # Local imports ----------------------------------------
     import pyhope.mesh.mesh_vars as mesh_vars
     import pyhope.output.output as hopout
+    from pyhope.basis.basis_basis import barycentric_weights, legendre_gauss_nodes
+    from pyhope.basis.basis_basis import calc_vandermonde, polynomial_derivative_matrix
+    from pyhope.basis.basis_orient import check_orientation
     from pyhope.common.common_progress import ProgressBar
     from pyhope.common.common_template import LoadTemplate
     from pyhope.common.common_tools import temporary_assign
     from pyhope.io.io_gmsh import GMSHCELLTYPES
     from pyhope.mesh.mesh_common import NDOFperElemType
-    from pyhope.mesh.mesh_orient import check_orientation
     from pyhope.mesh.mesh_vars import nGeo
     from pyhope.mesh.topology.mesh_topology import appendBCSet
     from pyhope.readintools.readintools import GetInt, GetStr
@@ -354,6 +356,17 @@ def MeshExtrude(mesh: meshio.Mesh) -> meshio.Mesh:
 
     # Temporarily assign mesh_vars.mesh
     with temporary_assign(mesh_vars, 'mesh', mesh):
+        # Compute the equidistant point set used by meshIO
+        xEq:       Final[npt.NDArray[np.float64]] = np.linspace(-1., 1., nGeo+1)
+        wBaryEq:   Final[npt.NDArray[np.float64]] = barycentric_weights(nGeo+1, xEq)
+
+        xGP, wGP  = legendre_gauss_nodes(nGeo+1)
+        DGP:       Final[npt.NDArray[np.float64]] = polynomial_derivative_matrix(nGeo+1, xGP)
+        VdmEqToGP: Final[npt.NDArray[np.float64]] = calc_vandermonde(nGeo+1, nGeo+1, wBaryEq, xEq, xGP)
+
+        # Compute the weights
+        weights:   Final[npt.NDArray[np.float64]] = np.outer(wGP, wGP)  # Shape: (N_GP+1, N_GP+1)
+
         # Check if the surface normal of the first cell points outwards
         for elemType in tuple(s for s in mesh.cells_dict if 'hexahedron' in s):
             # Only check the first element, other elements get covered in OrientMesh
@@ -364,7 +377,7 @@ def MeshExtrude(mesh: meshio.Mesh) -> meshio.Mesh:
             if isinstance(elemType, str):
                 elemType = elemNames[elemType]
 
-            if not check_orientation(ionodes, elemType)[0]:
+            if not check_orientation(ionodes, elemType, VdmEqToGP, DGP, weights)[0]:
                 hopout.error('Extruded element has inward pointing normal vector. Wrong extrusion direction?')
 
     # Run garbage collector to release memory

--- a/pyhope/script/pyhope_cli.py
+++ b/pyhope/script/pyhope_cli.py
@@ -45,6 +45,7 @@ def main() -> None:
     import pyhope.output.output as hopout
     from pyhope.basis.basis_connect import CheckConnect
     from pyhope.basis.basis_jacobian import CheckJacobians
+    from pyhope.basis.basis_orient import CheckOrient
     from pyhope.basis.basis_watertight import CheckWatertight
     from pyhope.check.check import Check
     from pyhope.common.common import DefineCommon, InitCommon
@@ -54,7 +55,6 @@ def main() -> None:
     from pyhope.mesh.fem.fem import FEMConnect
     from pyhope.mesh.mesh import DefineMesh, InitMesh, GenerateMesh
     from pyhope.mesh.mesh_duplicates import EliminateDuplicates
-    from pyhope.mesh.mesh_orient import OrientMesh
     from pyhope.mesh.mesh_sides import GenerateSides
     from pyhope.mesh.mesh_sort import SortMesh
     from pyhope.mesh.mesh_mortar import RebuildMortarGeometry
@@ -123,12 +123,15 @@ def main() -> None:
     hopout.sep()
 
     EliminateDuplicates()
-    if not args.skip_checks:
-        OrientMesh()
 
     # Build our data structures
     GenerateSides()
     SortMesh()
+
+    # Perform the mesh checks not depending on connectivity
+    if not args.skip_checks:
+        CheckOrient()
+
     ConnectMesh()
     TransformMesh()
 


### PR DESCRIPTION
Previously, we use the cross-product of the first two tangent vectors for the normal calculation. This can produce wrong results for highly deformed elements which are nonetheless correct. Perform the full high-order integration on the Jacobian to avoid this issue.